### PR TITLE
Changed yield in keys method so that an "as alias" clause may be used within the...

### DIFF
--- a/pgpy/keys.py
+++ b/pgpy/keys.py
@@ -218,7 +218,7 @@ class PGPKeyring(object):
         # trap exceptions raised while in the context managed state momentarily so cleanup is ensured
         # even when an exception is raised
         try:
-            yield
+            yield self
 
         finally:
             # destroy all decrypted secret key material here (if any) if it was encrypted when loaded


### PR DESCRIPTION
... managed context.

This allows for key activities to be written as:

``` python
with pubsec.key("DEADBEEF") as akey:
    if akey.selected_privkey.encrypted:
        akey.unlock("C0rrectPassphr@se")
```
