### PR TITLE
Fix enum metaclass on 3.6

### DIFF
--- a/pgpy/types.py
+++ b/pgpy/types.py
@@ -638,8 +638,12 @@ class FlagEnumMeta(EnumMeta):
         return self & other
 
 
-class FlagEnum(six.with_metaclass(FlagEnumMeta, IntEnum)):
-    pass
+if six.PY2:
+    class FlagEnum(IntEnum):
+        __metaclass__ = FlagEnumMeta
+else:
+    namespace = FlagEnumMeta.__prepare__("FlagEnum", (IntEnum,))
+    FlagEnum = FlagEnumMeta("FlagEnum", (IntEnum,), namespace)
 
 
 class Fingerprint(str):


### PR DESCRIPTION
This fixes #166 by using the old syntax for Python 2 and by manually
creating the type on Python 3. This should be considered a workaround
until six fixes metaclasses themselves (good luck to them, it'll be a
pain in the ass).