### PR TITLE
Add PGPKeyring.load() for PGPKey instance param.

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -2443,7 +2443,7 @@ class PGPKeyring(collections.Container, collections.Iterable, collections.Sized)
         Load all keys provided into this keyring object.
 
         :param \*args: Each arg in ``args`` can be any of the formats supported by :py:meth:`PGPKey.from_path` and
-                      :py:meth:`PGPKey.from_blob`, or a ``list`` or ``tuple`` of these.
+                      :py:meth:`PGPKey.from_blob` or a :py:class:`PGPKey` instance, or a ``list`` or ``tuple`` of these.
         :type \*args: ``list``, ``tuple``, ``str``, ``unicode``, ``bytes``, ``bytearray``
         :returns: a ``set`` containing the unique fingerprints of all of the keys that were loaded during this operation.
         """
@@ -2455,9 +2455,11 @@ class PGPKeyring(collections.Container, collections.Iterable, collections.Sized)
         loaded = set()
         for key in iter(item for ilist in iter(ilist if isinstance(ilist, (tuple, list)) else [ilist] for ilist in args)
                         for item in ilist):
-            if os.path.isfile(key):
+            keys = {}
+            if isinstance(key, PGPKey):
+                _key = key
+            elif os.path.isfile(key):
                 _key, keys = PGPKey.from_file(key)
-
             else:
                 _key, keys = PGPKey.from_blob(key)
 

--- a/tests/test_04_PGP_objects.py
+++ b/tests/test_04_PGP_objects.py
@@ -208,6 +208,21 @@ class TestPGPKeyring(object):
         assert not rvt[0].is_public
         assert rvt[1].is_public
 
+    @pytest.mark.parametrize('kf', _keyfiles, ids=[os.path.basename(f) for f in _keyfiles])
+    def test_load_key_instance(self, keyring, kf):
+        key, _ = PGPKey.from_file(kf)
+
+        keys = keyring.load(key)
+
+        assert key.fingerprint in keyring
+        for uid in key.userids:
+            if uid.name != "":
+                assert uid.name in keyring
+            if uid.email != "":
+                assert uid.email in keyring
+        with keyring.key(key.fingerprint) as loaded_key:
+            assert loaded_key.fingerprint == key.fingerprint
+
     def test_select_fingerprint(self, keyring):
         for fp, name in [("F429 4BC8 094A 7E05 85C8 5E86 3747 3B37 58C4 4F36", "RSA von TestKey"),
                          (six.u("F429 4BC8 094A 7E05 85C8 5E86 3747 3B37 58C4 4F36"), six.u("RSA von TestKey")),


### PR DESCRIPTION
This PR allows one to load a PGPKey into a PGPKeyring via the load method. A copy of the PGPKey is added to the keyring.