### PR TITLE
Fix armor regex being too greedy in cleartext matching.

### DIFF
--- a/pgpy/types.py
+++ b/pgpy/types.py
@@ -59,7 +59,7 @@ class Armorable(six.with_metaclass(abc.ABCMeta)):
     __armor_regex = re.compile(r"""# This capture group is optional because it will only be present in signed cleartext messages
                          (^-{5}BEGIN\ PGP\ SIGNED\ MESSAGE-{5}(?:\r?\n)
                           (Hash:\ (?P<hashes>[A-Za-z0-9\-,]+)(?:\r?\n){2})?
-                          (?P<cleartext>(.*\r?\n)+)(?:\r?\n)?
+                          (?P<cleartext>(.*\r?\n)+?)(?:\r?\n)?
                          )?
                          # armor header line; capture the variable part of the magic text
                          ^-{5}BEGIN\ PGP\ (?P<magic>[A-Z0-9 ,]+)-{5}(?:\r?\n)


### PR DESCRIPTION
33ba06fd623fb7f19d6298f96d1f7c4b70db50e1 broke cleartext matching where the cleartext group was too greedy and matched the newline which shouldn't have been, see [travis](https://travis-ci.org/SecurityInnovation/PGPy/builds/245600522?utm_source=github_status&utm_medium=notification).

This PR fixes it, tests should pass although I am not sure my solution is the one. As that's a fairly complex regex, so now it might be broken in some other way? Anyway, tests should pass now.

