### PR TITLE
Fix wrong hexadecimal number prefix in Packet.__repr__.

### DIFF
--- a/pgpy/packet/types.py
+++ b/pgpy/packet/types.py
@@ -160,7 +160,7 @@ class Packet(Dispatchable):
         return len(self.header) + self.header.length
 
     def __repr__(self):
-        return "<{cls:s} [tag 0x{tag:02d}] at 0x{id:x}>".format(cls=self.__class__.__name__, tag=self.header.tag, id=id(self))
+        return "<{cls:s} [tag {tag:02d}] at 0x{id:x}>".format(cls=self.__class__.__name__, tag=self.header.tag, id=id(self))
 
     def update_hlen(self):
         self.header.length = len(self.__bytearray__()) - len(self.header)
@@ -180,7 +180,7 @@ class VersionedPacket(Packet):
             self.header.version = self.__ver__
 
     def __repr__(self):
-        return "<{cls:s} [tag 0x{tag:02d}][v{ver:d}] at 0x{id:x}>".format(cls=self.__class__.__name__, tag=self.header.tag,
+        return "<{cls:s} [tag {tag:02d}][v{ver:d}] at 0x{id:x}>".format(cls=self.__class__.__name__, tag=self.header.tag,
                                                                           ver=self.header.version, id=id(self))
 
 


### PR DESCRIPTION
Packet tags are printed as decimal in the string and are also specified as decimal in the RFC4880, so dropping the `0x`.