### PR TITLE
Fix encrypt then sign.

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -351,7 +351,10 @@ class PGPSignature(Armorable, ParentRef, PGPObject):
             For binary document signatures (type 0x00), the document data is
             hashed directly.
             """
-            _data += bytearray(subject)
+            if isinstance(subject, (SKEData, IntegrityProtectedSKEData)):
+                _data += subject.__bytearray__()
+            else:
+                _data += bytearray(subject)
 
         if self.type == SignatureType.CanonicalDocument:
             """

--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -841,6 +841,8 @@ class PGPMessage(Armorable, PGPObject):
                 yield sig
 
         elif self.is_encrypted:
+            for sig in self._signatures:
+                yield sig
             for pkt in self._sessionkeys:
                 yield pkt
             yield self.message


### PR DESCRIPTION
This should fix #186 and #187 although this PR doesn't have tests(yet?). Also conflicts with #189. From [pgp.py#L814](https://github.com/SecurityInnovation/PGPy/blob/master/pgpy/pgp.py#L814) it seems that `__iter__` in `PGPMessage` should yield packets, however in it's current implementation it also yields `PGPSignature`.

```python
>>> list(smsg)
[<OnePassSignatureV3 [tag 0x04][v3] at 0x7fb99b877a20>, <LiteralData [tag 0x11] at 0x7fb99b877eb8>, <PGPSignature [BinaryDocument] object at 0x7fb99b88d828>]
````

#189 fixes that so iterating over all PGP* objects yields their packets at the cost of API change. See #189.