### PR TITLE
Don't raise when encountering an unknown key. Fixes #177 (partly).

### DIFF
--- a/pgpy/constants.py
+++ b/pgpy/constants.py
@@ -249,7 +249,8 @@ class PubKeyAlgorithm(IntEnum):
     #: Signifies that a key is an ECDSA key.
     ECDSA = 0x13
     FormerlyElGamalEncryptOrSign = 0x14  # deprecated - do not generate
-    # DiffieHellman = 0x15  # X9.42
+    DiffieHellman = 0x15  # X9.42
+    EdDSA = 0x16  # https://tools.ietf.org/html/draft-koch-eddsa-for-openpgp-04
 
     @property
     def can_gen(self):


### PR DESCRIPTION
Just makes `PGPKey.parse` on a packet with pubkey algorithm `== 0x15` or `== 0x16` not fail. The first one is mentioned in RFC 4880 as reserved for X9.42 IETF-S/MIME. The other comes from https://tools.ietf.org/html/draft-koch-eddsa-for-openpgp-04. OpenSSL has EdDSA support however the `cryptography` package doesn't yet expose it, so we cannot use those keys but will not fail while encountering them. This should fix #177.

I think we should also not fail while importing stuff with constant values from `range(100,110)` as that's Experimental/Private range and I think at least allowing loading of those into their concrete Opaque types makes sense. Since now, even loading a message which contains a packet signed with `PubKeyAlgorithm == 100` will fail even when the message might have a signature made by a key we understand and might wanna verify. As some RFCs already say, be conservative in what you send; be liberal in what you accept.