### PR TITLE
Fix Travis for forks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 os:
   - linux
   - osx


### PR DESCRIPTION
This should fix Travis CI builds of forks. Which for some strange reason complain of running on `sudo: false` while the main repo runs on `sudo: required` magically! :smile: