### PR TITLE
Fix PGPKey.from_blob('') not raising an exception. Fixes #199.

### DIFF
--- a/pgpy/types.py
+++ b/pgpy/types.py
@@ -86,10 +86,10 @@ class Armorable(six.with_metaclass(abc.ABCMeta)):
     @staticmethod
     def is_ascii(text):
         if isinstance(text, six.string_types):
-            return bool(re.match(r'^[ -~\r\n]+$', text, flags=re.ASCII))
+            return bool(re.match(r'^[ -~\r\n]*$', text, flags=re.ASCII))
 
         if isinstance(text, (bytes, bytearray)):
-            return bool(re.match(br'^[ -~\r\n]+$', text, flags=re.ASCII))
+            return bool(re.match(br'^[ -~\r\n]*$', text, flags=re.ASCII))
 
         raise TypeError("Expected: ASCII input of type str, bytes, or bytearray")  # pragma: no cover
 

--- a/tests/test_99_regressions.py
+++ b/tests/test_99_regressions.py
@@ -332,3 +332,9 @@ def test_oneline_cleartext(sf, cleartext):
     assert dearmor['magic'] == 'SIGNATURE'
     # No newline at the end
     assert dearmor['cleartext'] == cleartext
+
+
+@pytest.mark.regression(issue=199)
+def test_armorable_empty_str():
+    with pytest.raises(ValueError, message='Expected: ASCII-armored PGP data'):
+        Armorable.ascii_unarmor('')


### PR DESCRIPTION
Makes an empty string not dearmor like a valid ASCII-Armored blob.