### PR TITLE
Add revocation_signatures property to PGPKey.

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1374,6 +1374,15 @@ class PGPKey(Armorable, ParentRef, PGPObject):
         return {sig.signer for sig in self.__sig__}
 
     @property
+    def revocation_signatures(self):
+        keyid, keytype = (self.fingerprint.keyid, SignatureType.KeyRevocation) if self.is_primary \
+            else (self.parent.fingerprint.keyid, SignatureType.SubkeyRevocation)
+
+        for sig in iter(sig for sig in self._signatures
+                        if all([sig.type == keytype, sig.signer == keyid, not sig.is_expired])):
+            yield sig
+
+    @property
     def subkeys(self):
         """An :py:obj:`~collections.OrderedDict` of subkeys bound to this primary key, if applicable,
         selected by 16-character keyid."""

--- a/tests/test_05_actions.py
+++ b/tests/test_05_actions.py
@@ -488,6 +488,7 @@ class TestPGPKey_Management(object):
 
         # verify with PGPy
         assert key.verify(subkey, rsig)
+        assert rsig in subkey.revocation_signatures
 
         # try to verify with GPG
         self.gpg_verify_key(key)
@@ -510,6 +511,7 @@ class TestPGPKey_Management(object):
 
         # verify with PGPy
         assert key.verify(key, rsig)
+        assert rsig in key.revocation_signatures
 
         # try to verify with GPG
         self.gpg_verify_key(key)


### PR DESCRIPTION
Exposes the revocation signatures of the key(primary or sub), as they are filtered out of the `self_signatures` property.
```
...
 OpenPGP users may transfer public keys.  The essential elements of a
   transferable public key are as follows:

     - One Public-Key packet

     - Zero or more revocation signatures
...
```