### PR TITLE
Parse partial length headers correctly.

### DIFF
--- a/tests/test_02_packets.py
+++ b/tests/test_02_packets.py
@@ -40,16 +40,12 @@ def binload(f):
         return buf
 
 
-skip_files = {'tests/testdata/packets/{:s}'.format(pkt) for pkt in ['11.partial.literal']}
 pktfiles = sorted(glob.glob('tests/testdata/packets/[0-9]*'))
 
 
 class TestPacket(object):
     @pytest.mark.parametrize('packet', pktfiles, ids=[os.path.basename(f) for f in pktfiles])
     def test_load(self, packet):
-        if packet in skip_files:
-            pytest.skip("not implemented yet")
-
         b = binload(packet) + _trailer
         _b = b[:]
         p = Packet(_b)
@@ -59,11 +55,12 @@ class TestPacket(object):
 
         # length is computed correctly
         assert p.header.length + len(p.header) == len(p)
-        assert len(p) == len(b) - len(_trailer)
-        assert len(p.__bytes__()) == len(b) - len(_trailer)
+        if packet not in ('tests/testdata/packets/11.partial.literal',):
+            assert len(p) == len(b) - len(_trailer)
+            assert len(p.__bytes__()) == len(b) - len(_trailer)
 
-        # __bytes__ output is correct
-        assert p.__bytes__() == b[:-len(_trailer)]
+            # __bytes__ output is correct
+            assert p.__bytes__() == b[:-len(_trailer)]
 
         # instantiated class is what we expected
         if hasattr(p.header, 'version') and (p.header.tag, p.header.version) in _pclasses:


### PR DESCRIPTION
This adds support for partial length headers, currently only parsing them, not emitting them. With this PR PGPy can decode a partial length packet of indefinite length, however when outputing said packet back to bytes, it will be a packet with the usual 1 / 2 / 5 octet length, which means that packets with contents larger than `4,294,968,295 (0xFFFFFFFF)` octets will be output incorrectly.

However, currently PGPy will not even parse those packets, so I believe this is an improvement that covers a large part of the use-cases of PGP.

To get PGPy to output partial length packets for packets larger than the 5 octet length limit, significant changes to the `__bytearray__` logic will be required, as then, the packet header will need to insert bytes into the packet data itself. The current inheritance model doesn't make it easy.