### PR TITLE
Fix bogus print in PGPKey.__copy__.

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1525,7 +1525,6 @@ class PGPKey(Armorable, ParentRef, PGPObject):
                 # embedded signatures don't need to be explicitly copied
                 continue
 
-            print(len(key._signatures))
             key |= copy.copy(sig)
 
         return key


### PR DESCRIPTION
Removes a left out debug print in `PGPKey.__copy__`.