### PR TITLE
Fix sigsubj.by to be a pgpy.PGPKey instance. Fixes #214.

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -2142,7 +2142,7 @@ class PGPKey(Armorable, ParentRef, PGPObject):
                 if verified is NotImplemented:
                     raise NotImplementedError(sig.key_algorithm)
 
-                sigv.add_sigsubj(sig, self.fingerprint.keyid, subj, verified)
+                sigv.add_sigsubj(sig, self, subj, verified)
 
         return sigv
 


### PR DESCRIPTION
This is indeed API breaking, however, the docstring clearly states what should be returned. Fixes #214.