### PR TITLE
WIP: blindly change all encoding to UTF-8

### DIFF
--- a/pgpy/packet/fields.py
+++ b/pgpy/packet/fields.py
@@ -837,7 +837,7 @@ class String2Key(Field):
 
         # Simple S2K - always done
         hsalt = b''
-        hpass = passphrase.encode('latin-1')
+        hpass = passphrase.encode('utf-8')
 
         # salted, iterated S2K
         if self.specifier >= String2KeyType.Salted:

--- a/pgpy/packet/packets.py
+++ b/pgpy/packet/packets.py
@@ -162,7 +162,7 @@ class PKESessionKeyV3(PKESessionKey):
 
     @encrypter.register(bytearray)
     def encrypter_bin(self, val):
-        self._encrypter = binascii.hexlify(val).upper().decode('latin-1')
+        self._encrypter = binascii.hexlify(val).upper().decode('utf-8')
 
     @sdproperty
     def pkalg(self):
@@ -670,7 +670,7 @@ class OnePassSignatureV3(OnePassSignature):
 
     @signer.register(bytearray)
     def signer_bin(self, val):
-        self._signer = binascii.hexlify(val).upper().decode('latin-1')
+        self._signer = binascii.hexlify(val).upper().decode('utf-8')
 
     def __init__(self):
         super(OnePassSignatureV3, self).__init__()
@@ -1155,7 +1155,7 @@ class LiteralData(Packet):
     @property
     def contents(self):
         if self.format == 't':
-            return self._contents.decode('latin-1')
+            return self._contents.decode('utf-8')
 
         if self.format == 'u':
             return self._contents.decode('utf-8')
@@ -1172,9 +1172,9 @@ class LiteralData(Packet):
     def __bytearray__(self):
         _bytes = bytearray()
         _bytes += super(LiteralData, self).__bytearray__()
-        _bytes += self.format.encode('latin-1')
+        _bytes += self.format.encode('utf-8')
         _bytes += bytearray([len(self.filename)])
-        _bytes += self.filename.encode('latin-1')
+        _bytes += self.filename.encode('utf-8')
         _bytes += self.int_to_bytes(calendar.timegm(self.mtime.timetuple()), 4)
         _bytes += self._contents
         return _bytes
@@ -1307,7 +1307,7 @@ class UserID(Packet):
     def parse(self, packet):
         super(UserID, self).parse(packet)
 
-        uid_text = packet[:self.header.length].decode('latin-1')
+        uid_text = packet[:self.header.length].decode('utf-8')
         del packet[:self.header.length]
 
         # came across a UID packet with no payload. If that happens, don't bother trying to parse anything!

--- a/pgpy/packet/subpackets/signature.py
+++ b/pgpy/packet/subpackets/signature.py
@@ -69,7 +69,7 @@ class URI(Signature):
 
     @uri.register(bytearray)
     def uri_bytearray(self, val):
-        self.uri = val.decode('latin-1')
+        self.uri = val.decode('utf-8')
 
     def __init__(self):
         super(URI, self).__init__()
@@ -418,7 +418,7 @@ class RegularExpression(Signature):
 
     @regex.register(bytearray)
     def regex_bytearray(self, val):
-        self.regex = val.decode('latin-1')
+        self.regex = val.decode('utf-8')
 
     def __init__(self):
         super(RegularExpression, self).__init__()
@@ -583,7 +583,7 @@ class Issuer(Signature):
 
     @issuer.register(bytearray)
     def issuer_bytearray(self, val):
-        self._issuer = binascii.hexlify(val).upper().decode('latin-1')
+        self._issuer = binascii.hexlify(val).upper().decode('utf-8')
 
     def __init__(self):
         super(Issuer, self).__init__()
@@ -631,7 +631,7 @@ class NotationData(Signature):
 
     @name.register(bytearray)
     def name_bytearray(self, val):
-        self.name = val.decode('latin-1')
+        self.name = val.decode('utf-8')
 
     @sdproperty
     def value(self):
@@ -645,7 +645,7 @@ class NotationData(Signature):
     @value.register(bytearray)
     def value_bytearray(self, val):
         if NotationDataFlags.HumanReadable in self.flags:
-            self.value = val.decode('latin-1')
+            self.value = val.decode('utf-8')
 
         else:  # pragma: no cover
             self._value = val
@@ -757,7 +757,7 @@ class SignersUserID(Signature):
 
     @userid.register(bytearray)
     def userid_bytearray(self, val):
-        self.userid = val.decode('latin-1')
+        self.userid = val.decode('utf-8')
 
     def __init__(self):
         super(SignersUserID, self).__init__()
@@ -801,7 +801,7 @@ class ReasonForRevocation(Signature):
 
     @string.register(bytearray)
     def string_bytearray(self, val):
-        self.string = val.decode('latin-1')
+        self.string = val.decode('utf-8')
 
     def __init__(self):
         super(ReasonForRevocation, self).__init__()

--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -339,7 +339,7 @@ class PGPSignature(Armorable, ParentRef, PGPObject):
         _data = bytearray()
 
         if isinstance(subject, six.string_types):
-            subject = subject.encode('latin-1')
+            subject = subject.encode('utf-8')
 
         """
         All signatures are formed by producing a hash over the signature
@@ -2195,7 +2195,7 @@ class PGPKey(Armorable, ParentRef, PGPObject):
 
         # set up a new PKESessionKeyV3
         pkesk = PKESessionKeyV3()
-        pkesk.encrypter = bytearray(binascii.unhexlify(self.fingerprint.keyid.encode('latin-1')))
+        pkesk.encrypter = bytearray(binascii.unhexlify(self.fingerprint.keyid.encode('utf-8')))
         pkesk.pkalg = self.key_algorithm
         # pkesk.encrypt_sk(self.__key__, cipher_algo, sessionkey)
         pkesk.encrypt_sk(self._key, cipher_algo, sessionkey)

--- a/pgpy/types.py
+++ b/pgpy/types.py
@@ -102,7 +102,7 @@ class Armorable(six.with_metaclass(abc.ABCMeta)):
         :returns: Whether the text is ASCII-armored.
         """
         if isinstance(text, (bytes, bytearray)):  # pragma: no cover
-            text = text.decode('latin-1')
+            text = text.decode('utf-8')
 
         return Armorable.__armor_regex.search(text) is not None
 
@@ -123,7 +123,7 @@ class Armorable(six.with_metaclass(abc.ABCMeta)):
             return m
 
         if isinstance(text, (bytes, bytearray)):  # pragma: no cover
-            text = text.decode('latin-1')
+            text = text.decode('utf-8')
 
         m = Armorable.__armor_regex.search(text)
 
@@ -200,7 +200,7 @@ class Armorable(six.with_metaclass(abc.ABCMeta)):
     def from_blob(cls, blob):
         obj = cls()
         if (not isinstance(blob, six.binary_type)) and (not isinstance(blob, bytearray)):
-            po = obj.parse(bytearray(blob, 'latin-1'))
+            po = obj.parse(bytearray(blob, 'utf-8'))
 
         else:
             po = obj.parse(bytearray(blob))
@@ -216,14 +216,14 @@ class Armorable(six.with_metaclass(abc.ABCMeta)):
         self.ascii_headers['Version'] = 'PGPy v' + __version__  # Default value
 
     def __str__(self):
-        payload = base64.b64encode(self.__bytes__()).decode('latin-1')
+        payload = base64.b64encode(self.__bytes__()).decode('utf-8')
         payload = '\n'.join(payload[i:(i + 64)] for i in range(0, len(payload), 64))
 
         return self.__armor_fmt.format(
             block_type=self.magic,
             headers=''.join('{key}: {val}\n'.format(key=key, val=val) for key, val in self.ascii_headers.items()),
             packet=payload,
-            crc=base64.b64encode(PGPObject.int_to_bytes(self.crc24(self.__bytes__()), 3)).decode('latin-1')
+            crc=base64.b64encode(PGPObject.int_to_bytes(self.crc24(self.__bytes__()), 3)).decode('utf-8')
         )
 
     def __copy__(self):
@@ -707,7 +707,7 @@ class Fingerprint(str):
 
         if isinstance(other, (six.text_type, bytes, bytearray)):
             if isinstance(other, (bytes, bytearray)):  # pragma: no cover
-                other = other.decode('latin-1')
+                other = other.decode('utf-8')
 
             other = str(other).replace(' ', '')
             return any([self.replace(' ', '') == other,

--- a/tests/test_99_regressions.py
+++ b/tests/test_99_regressions.py
@@ -156,7 +156,7 @@ def test_reg_bug_56():
         key_data = gpg.Data(string=pub)
         gpg.core.gpgme.gpgme_op_import(c.wrapped, key_data)
 
-        _, vres = c.verify(gpg.Data(string=sigsubject.decode('latin-1')), gpg.Data(string=str(sig)))
+        _, vres = c.verify(gpg.Data(string=sigsubject.decode('utf-8')), gpg.Data(string=str(sig)))
     assert vres
 
 


### PR DESCRIPTION
My public key doesn't properly decode when loaded with PGPy:

In [38]: pgpy.PGPKey.from_file('anarcat.gpg')[0].userids[0].name
Out[38]: 'Antoine BeauprÃ©'

By switching to UTF-8 everywhere, it gets properly parsed. Using
Latin-1 is not a right default: it is europe-centric and will
necessarily break whenever another language than english or some
european countries is used (e.g. any asian language will fail). As you
can see, even french accents fail, if they are (properly) encoded in
UTF-8.

This is a stopgap measure: I am not sure how to decode user
identifiers properly, nor if this touches on too much stuff to fix the
actual problem. But I would assert that using UTF-8 is a better
default than latin-1.