### PR TITLE
add convenience accessor for revocation keys

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1389,6 +1389,15 @@ class PGPKey(Armorable, ParentRef, PGPObject):
         """A ``list`` of :py:obj:`PGPUID` objects containing one or more images associated with this key"""
         return [u for u in self._uids if u.is_ua]
 
+    @property
+    def revocation_keys(self):
+        """A ``generator`` with the list of keys that can revoke this key.
+
+        See also :py:func:`PGPSignature.revocation_key`"""
+        for sig in self._signatures:
+            if sig.revocation_key:
+                yield sig.revocation_key
+
     @classmethod
     def new(cls, key_algorithm, key_size):
         """


### PR DESCRIPTION
It may not be obvious for users of the API that we can get the list of
revoker keys for a given key from the (private) _signature list, so
add a convenient accessor.

This is not really useful right now because it will raise a
NotImplementedError if any such signature is found, but will become
actually quite useful once #198 lands.

This is part of the process to make revocation checks easier in #225.