### PR TITLE
pubkey method copies parent to newly generated public key

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -416,7 +416,7 @@ class PGPSignature(Armorable, ParentRef, PGPObject):
             by the top-level signature key that is bound to this subkey, or
             by an authorized revocation key, should be considered valid
             revocation signatures.
-            
+
             - clarification from draft-ietf-openpgp-rfc4880bis-02:
             Primary key revocation signatures (type 0x20) hash
             only the key being revoked.  Subkey revocation signature (type 0x28)
@@ -1343,6 +1343,9 @@ class PGPKey(Armorable, ParentRef, PGPObject):
                 # keep connect the two halves using a weak reference
                 self._sibling = weakref.ref(pub)
                 pub._sibling = weakref.ref(self)
+
+                # copy parent
+                pub._parent = self.parent
 
             return self._sibling()
         return None

--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1345,7 +1345,8 @@ class PGPKey(Armorable, ParentRef, PGPObject):
                 pub._sibling = weakref.ref(self)
 
                 # copy parent
-                pub._parent = self.parent
+                if self.parent:
+                    pub._parent = weakref.ref(self.parent)
 
             return self._sibling()
         return None


### PR DESCRIPTION
I discovered this issue when trying to encrypt a string with a subkey. Stack trace:

```
  File "sowbug-file.py", line xxx, in xxx
    x = key.encrypt(pgpy.PGPMessage.new("hi"))
  File "myenv/local/lib/python2.7/site-packages/pgpy/decorators.py", line 125, in _action
    with self.usage(key, kwargs.get('user', None)) as _key:
  File "/usr/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "myenv/local/lib/python2.7/site-packages/pgpy/decorators.py", line 92, in usage
    if self.flags & set(_key._get_key_flags(user)):
  File "myenv/local/lib/python2.7/site-packages/pgpy/pgp.py", line 1715, in _get_key_flags
    return next(self.self_signatures).key_flags
  File "myenv/local/lib/python2.7/site-packages/pgpy/pgp.py", line 1366, in self_signatures
    else (self.parent.fingerprint.keyid, SignatureType.Subkey_Binding)
AttributeError: 'NoneType' object has no attribute 'fingerprint'

```

Sure enough, `parent` is None. This happens when I create the key with `primary.subkeys.items()[0][1].pubkey`. I think that method should be copying `parent` along with the other fields it is copying. I don't know whether it's correct for it to be a normal assignment or a weakref. Please think about that before accepting this pull request.

By the way, it's possible this has gone unnoticed because people are usually generating RSA keys, and they are mistakenly encrypting with the primary key rather than the subkey used for encryption, but they don't notice because RSA can encrypt and sign. In my case I generated an ECDSA primary key along with an ECDH subkey for encryption, so my code failed because you can't encrypt with ECDSA. That's what caused me to remember I needed to reference the subkey, not the primary.