### PR TITLE
#243 - Pick first _supported_ algorithm from preference list

### DIFF
--- a/pgpy/constants.py
+++ b/pgpy/constants.py
@@ -200,6 +200,10 @@ class SymmetricKeyAlgorithm(IntEnum):
         raise NotImplementedError(repr(self))
 
     @property
+    def is_supported(self):
+        return callable(self.cipher)
+
+    @property
     def is_insecure(self):
         insecure_ciphers = {SymmetricKeyAlgorithm.IDEA}
         return self in insecure_ciphers
@@ -350,6 +354,10 @@ class HashAlgorithm(IntEnum):
             self.tune_count()
 
         return self._tuned_count
+
+    @property
+    def is_supported(self):
+        return True
 
     def tune_count(self):
         start = end = 0

--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1736,7 +1736,7 @@ class PGPKey(Armorable, ParentRef, PGPObject):
                 uid = next(iter(self.parent.userids), None)
 
         if sig.hash_algorithm is None:
-            sig._signature.halg = uid.selfsig.hashprefs[0]
+            sig._signature.halg = next(h for h in uid.selfsig.hashprefs if h.is_supported)
 
         if uid is not None and sig.hash_algorithm not in uid.selfsig.hashprefs:
             warnings.warn("Selected hash algorithm not in key preferences", stacklevel=4)
@@ -2188,7 +2188,8 @@ class PGPKey(Armorable, ParentRef, PGPObject):
             uid = next(iter(self.userids), None)
             if uid is None and self.parent is not None:
                 uid = next(iter(self.parent.userids), None)
-        cipher_algo = prefs.pop('cipher', uid.selfsig.cipherprefs[0])
+        pref_cipher = next(c for c in uid.selfsig.cipherprefs if c.is_supported)
+        cipher_algo = prefs.pop('cipher', pref_cipher)
 
         if cipher_algo not in uid.selfsig.cipherprefs:
             warnings.warn("Selected symmetric algorithm not in key preferences", stacklevel=3)

--- a/pgpy/symenc.py
+++ b/pgpy/symenc.py
@@ -24,7 +24,7 @@ def _encrypt(pt, key, alg, iv=None):
     if alg.is_insecure:
         raise PGPInsecureCipher("{:s} is not secure. Do not use it for encryption!".format(alg.name))
 
-    if not callable(alg.cipher):
+    if not alg.is_supported:
         raise PGPEncryptionError("Cipher {:s} not supported".format(alg.name))
 
     try:

--- a/tests/test_99_regressions.py
+++ b/tests/test_99_regressions.py
@@ -370,3 +370,40 @@ def test_verify_subkey_revocation_signature():
     revsig = subkey._signatures[1]
 
     assert pubkey.verify(subkey, revsig)
+
+@pytest.mark.regression(issue=243)
+def test_preference_unsupported_ciphers():
+    from pgpy import PGPMessage
+    keyblob = ('-----BEGIN PGP PUBLIC KEY BLOCK-----\n'
+               '\n'
+               'mQENBFtKbSQBCADDMwreTvJkDQkgB+n0GsNbMFKEjPYGKP365y5w+FlJ2zg69F3W\n'
+               'ituYFQcTwuge2XSh58k/XHln+MwjNc5cDQaWLtMuyJbRvLK+8MdpdYlzrlyrsgDI\n'
+               'L/1PAlGMVWB83Iu2kxqc0ppTxwsltAcvRJBE+9oSiWRACQviDmX5LeBmPoGqM93w\n'
+               'LeN3QT/tu26rxha374HPgSqqNR13r3xl7gQre+pA3jmNQqwzPnEmUKN3hO852NAw\n'
+               'QOPbf4yTCcbeZ6iZ/h0mW4DvbLiPbzUsXRvgTo3X/kzJD+ZnznvJvjcKrkXzaOAp\n'
+               'qt6Nd1LmWyv5h7gBYgBNaQONFeMl9MVBFUflABEBAAG0GnRlc3RrZXkgPHRlc3RA\n'
+               'ZXhhbXBsZS5jb20+iQFPBBMBCAA5AhsDAh4BAheAFiEEL7Bmz7+mS4Q3LDSMbIbe\n'
+               'TttFc4wFAltKbXsFCwoJCAcGFQoJCAsCBRYCAwEAAAoJEGyG3k7bRXOMI34IAINL\n'
+               'bYmZ95RgVX98+tjBAliV9xZaaxu4xpY8vz4pCwwFj9QBMxkzmITC1yb/Vav6pLFK\n'
+               'UISLGeOUqskVg9uQn8YGSnRaKoxetL894o0jGLyQF6ujF4OFhbfRlaLbNACDQqg0\n'
+               'bzV1E+s6RsnbwR7aFlOcgz5m/j7+c9t/BnZ4qOYBW85iLyzQA4BgTBSocdyom3EA\n'
+               'osCNY4tFuySFlOF34OLu1k8y9RP0KsJJptEdIwEqSxRKuQ5KTbopx9kvxVfOOwgy\n'
+               'RVYuP/OQrc/MQPGSC0Rmh/iCNEsTOIxcwnotmyRd8qDpw/EBj1a0iWxzPYOzXoEQ\n'
+               'Ff2ipWRkzS3AyWVJJxi5AQ0EW0ptJAEIAJXwfVD+3oSLPedMBvpfnveu/LjFvxJk\n'
+               'ohawApu63JzJNXoRpjeBhox073iEjeSbvq/pJ/+y0t6KkFZXoXgpqACGDNjPpojk\n'
+               '6YTo6Da7GpyXefhKyH4IQ9Lbd9UIEhOKfktXTJfR/EoCZb+rmTm0WnjwkwOAVdQv\n'
+               'vuMRm8Hc39xn+Mt0CV+0KcYHhNfK+A2XU6bZkHuwaTzxTaotmeLeCgC+BA2Phwxp\n'
+               'BIhkSNE8ayYLN0VBPraw28xONzNV5e6f8RWNoGTDQxhZflmvIGz/XO5wo1DV1G0k\n'
+               'VIR49brAmrapqpCW7XWhuuupVbrpbjRUa+c4G03tySXQXUTdA3etH0EAEQEAAYkB\n'
+               'NgQYAQgAIBYhBC+wZs+/pkuENyw0jGyG3k7bRXOMBQJbSm0kAhsMAAoJEGyG3k7b\n'
+               'RXOMKbMIAKymk6Fe1qpjXtK56jpMurz1wBL0/twQbvtKQlgMBNdro0MX30xKGXh1\n'
+               'rCEIV3ls7CJnUm2NEeqFPzFZhsZS2FkgDXXT20K3S6nscv8xlF2z+jktK2RY6oCJ\n'
+               'Lgw447Rgjw5ARgW2XNrGRzapAf4KBgcyO1KtTCbjh8leg4Fs1O7B8EbiBvoeUJR0\n'
+               'wj2xNG4cOHoWN7Zjv8lLsJn60+ZbTeU25ghybmt7WjCs4ht7TZmamerLPzrFvP2c\n'
+               'ftLsb17HhrBPdfs42SsD8A816JDM7PcJWujlDV9FPJgoVjndK+4Jfpg9b4jOBA7J\n'
+               '7zeGuobtKdS9Y97BVFNtTPZK66YUIEQ=\n'
+               '=lGIy\n'
+               '-----END PGP PUBLIC KEY BLOCK-----\n')
+    pubkey, _ = PGPKey.from_blob(keyblob)
+    msg = PGPMessage.new('asdf')
+    pubkey.encrypt(msg)


### PR DESCRIPTION
- Add a `is_supported` property to symmetric ciphers and hash algorithms
  in pgpy.constants.
  At the moment, a hash algorithm is always supported.
  A cipher algorithm is supported iff its .cipher is callable.

- When picking a preferred cipher from a preference list,
  pick the first _supported_ one, instead of the first one.

- Check for `alg.is_supported` instead of `callable(alg.cipher)`
  in pgpy.symenc._encrypt
---
This is a quickly sketched fix for #243.
There's a regression test that fails before it and passes after it, so I'm fairly sure it does fix the issue.