### PR TITLE
test: stop not being expired, on static date

### DIFF
--- a/tests/test_03_armor.py
+++ b/tests/test_03_armor.py
@@ -133,7 +133,10 @@ block_attrs = {
         [('created',       datetime(2014, 9, 11, 22, 55, 53)),
          ('fingerprint',   "AE15 9FF3 4C1A 2426 B7F8 0F1A 560C F308 EF60 CFA3"),
          ('expires_at',    datetime(2018, 9, 12, 1, 0, 59)),
-         ('is_expired',    False),
+         # is_expired was False until the date above.
+         # If there'are other tests depending on static testdata
+         # expirations dates, they will also fail in the future.
+         ('is_expired',    True),
          ('is_primary',    True),
          ('is_protected',  False),
          ('is_public',     True),


### PR DESCRIPTION
tests/test_03_armor.py::block_attrs was setting:
"block.is_expired = False"
Which was correct at the time the test was created, but it's no
longer true based on the the expiration date in revochiio.asc
("datetime(2018, 9, 12, 1, 0, 59))")
While there's not mocking on times, tests should not relay on
dates.
If there are more tests depending on dates, they will fail in the
future too.