### PR TITLE
Support for S2K GNU extensions

### DIFF
--- a/pgpy/constants.py
+++ b/pgpy/constants.py
@@ -431,6 +431,12 @@ class String2KeyType(IntEnum):
     Salted = 1
     Reserved = 2
     Iterated = 3
+    GNUExtension = 101
+
+
+class S2KGNUExtension(IntEnum):
+    NoSecrete = 1
+    Smartcard = 2
 
 
 class TrustLevel(IntEnum):

--- a/pgpy/constants.py
+++ b/pgpy/constants.py
@@ -33,6 +33,7 @@ __all__ = ['Backend',
            'ImageEncoding',
            'SignatureType',
            'KeyServerPreferences',
+           'S2KGNUExtension',
            'String2KeyType',
            'TrustLevel',
            'KeyFlags',
@@ -435,7 +436,7 @@ class String2KeyType(IntEnum):
 
 
 class S2KGNUExtension(IntEnum):
-    NoSecrete = 1
+    NoSecret = 1
     Smartcard = 2
 
 

--- a/pgpy/packet/fields.py
+++ b/pgpy/packet/fields.py
@@ -793,6 +793,9 @@ class String2Key(Field):
         # iterated
         self.count = 0
 
+        # GNU extension default type: ignored if specifier != GNUExtension
+        self.gnuext = 1
+
         # GNU extension smartcard
         self.scserial = None
 
@@ -802,7 +805,7 @@ class String2Key(Field):
         if bool(self):
             _bytes.append(self.encalg)
             _bytes.append(self.specifier)
-            if self.specifier > String2KeyType.Iterated:
+            if self.specifier == String2KeyType.GNUExtension:
                 return self._experimental_bytearray(_bytes)
             if self.specifier >= String2KeyType.Simple:
                 _bytes.append(self.halg)
@@ -856,7 +859,7 @@ class String2Key(Field):
             self.specifier = packet[0]
             del packet[0]
 
-            if self.specifier > String2KeyType.Iterated:
+            if self.specifier == String2KeyType.GNUExtension:
                 return self._experimental_parse(packet, iv)
 
             if self.specifier >= String2KeyType.Simple:

--- a/tests/test_01_packetfields.py
+++ b/tests/test_01_packetfields.py
@@ -7,6 +7,7 @@ import itertools
 from pgpy.constants import HashAlgorithm
 from pgpy.constants import String2KeyType
 from pgpy.constants import SymmetricKeyAlgorithm
+from pgpy.constants import S2KGNUExtension
 from pgpy.packet.fields import String2Key
 from pgpy.packet.types import Header
 from pgpy.packet.subpackets import Signature
@@ -294,6 +295,12 @@ _s2k_parts = [
 _iv = b'\xDE\xAD\xBE\xEF\xDE\xAD\xBE\xEF'
 _salt = b'\xC0\xDE\xC0\xDE\xC0\xDE\xC0\xDE'
 _count = b'\x10'  # expands from 0x10 to 2048
+_gnu_scserials = [
+    # standard 16 bytes serial
+    bytearray(range(16)),
+    # shorter serial
+    b'\x42\x43\x44\x45'
+    ]
 
 # simple S2Ks
 sis2ks = [bytearray(i) + _iv for i in itertools.product(*(_s2k_parts[:2] + [b'\x00'] + _s2k_parts[2:]))]
@@ -301,6 +308,8 @@ sis2ks = [bytearray(i) + _iv for i in itertools.product(*(_s2k_parts[:2] + [b'\x
 sas2ks = [bytearray(i) + _salt + _iv for i in itertools.product(*(_s2k_parts[:2] + [b'\x01'] + _s2k_parts[2:]))]
 # iterated S2Ks
 is2ks = [bytearray(i) + _salt + _count + _iv for i in itertools.product(*(_s2k_parts[:2] + [b'\x03'] + _s2k_parts[2:]))]
+# GNU extension S2Ks
+gnus2ks = [bytearray(b'\xff\x00\x65\x00GNU' + i) for i in ([b'\x01'] + [b'\x02' + bytearray([len(s)]) + s for s in _gnu_scserials])]
 
 
 class TestString2Key(object):
@@ -354,3 +363,20 @@ class TestString2Key(object):
         assert s.salt == _salt
         assert s.count == 2048
         assert s.iv == _iv
+
+    @pytest.mark.parametrize('gnus2k', gnus2ks)
+    def test_gnu_extension_string2key(self, gnus2k):
+        b = gnus2k[:]
+        s = String2Key()
+        s.parse(gnus2k)
+
+        assert len(gnus2k) == 0
+        assert len(s) == len(b)
+        assert s.__bytes__() == b
+
+        assert bool(s)
+        assert s.encalg == SymmetricKeyAlgorithm.Plaintext
+        assert s.specifier == String2KeyType.GNUExtension
+        assert s.gnuext in S2KGNUExtension
+        if s.gnuext == S2KGNUExtension.Smartcard:
+            assert s.scserial is not None and len(s.scserial) <= 16


### PR DESCRIPTION
Support for the String2Key [GNU extensions](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=doc/DETAILS;h=3046523da62c576cf6a765a8b0829876cfdc6b3b;hb=b0f0791e4ade845b2a0e2a94dbda4f3bf1ceb039#l1346).

1. Private key without the secret values, e.g., parent certify key kept on a separate offline machine.
2. Private key with secrete values stored on smartcard.