### PR TITLE
Set creation times

### DIFF
--- a/pgpy/packet/packets.py
+++ b/pgpy/packet/packets.py
@@ -856,13 +856,15 @@ class PrivKeyV4(PrivKey, PubKeyV4):
     __ver__ = 4
 
     @classmethod
-    def new(cls, key_algorithm, key_size):
+    def new(cls, key_algorithm, key_size, created=None):
         # build a key packet
         pk = PrivKeyV4()
         pk.pkalg = key_algorithm
         if pk.keymaterial is None:
             raise NotImplementedError(key_algorithm)
         pk.keymaterial._generate(key_size)
+        if created is not None:
+            pk.created = created
         pk.update_hlen()
         return pk
 

--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1430,7 +1430,7 @@ class PGPKey(Armorable, ParentRef, PGPObject):
         return [u for u in self._uids if u.is_ua]
 
     @classmethod
-    def new(cls, key_algorithm, key_size):
+    def new(cls, key_algorithm, key_size, created=None):
         """
         Generate a new PGP key
 
@@ -1439,6 +1439,9 @@ class PGPKey(Armorable, ParentRef, PGPObject):
         :param key_size: Key size in bits, unless `key_algorithm` is :py:obj:`~constants.PubKeyAlgorithm.ECDSA` or
                :py:obj:`~constants.PubKeyAlgorithm.ECDH`, in which case it should be the Curve OID to use.
         :type key_size: ``int`` or :py:obj:`~constants.EllipticCurveOID`
+
+        :param created: When was the key created? (None or unset means now)
+        :type created: :py:obj:`~datetime.datetime` or None
         :return: A newly generated :py:obj:`PGPKey`
         """
         # new private key shell first
@@ -1449,7 +1452,7 @@ class PGPKey(Armorable, ParentRef, PGPObject):
             key_algorithm = PubKeyAlgorithm.RSAEncryptOrSign
 
         # generate some key data to match key_algorithm and key_size
-        key._key = PrivKeyV4.new(key_algorithm, key_size)
+        key._key = PrivKeyV4.new(key_algorithm, key_size, created=created)
 
         return key
 


### PR DESCRIPTION
when creating an OpenPGP public key, or an OpenPGP signature packet, it can be handy to be able to set the creation time manually, rather than relying on the system clock.   These changes make that possible (but everything still works with the system clock if they are not set deliberately).