### PR TITLE
test the names of the curves against the stored list

### DIFF
--- a/tests/test_05_actions.py
+++ b/tests/test_05_actions.py
@@ -254,8 +254,8 @@ class TestPGPKey_Management(object):
         if not alg.can_gen:
             pytest.xfail('Key algorithm {} not yet supported'.format(alg.name))
 
-        if isinstance(size, EllipticCurveOID) and ((not size.can_gen) or size.name not in _openssl_get_supported_curves()):
-            pytest.xfail('Curve {} not yet supported'.format(size.name))
+        if isinstance(size, EllipticCurveOID) and ((not size.can_gen) or size.curve.name not in _openssl_get_supported_curves()):
+            pytest.xfail('Curve {} not yet supported'.format(size.curve.name))
 
         key = self.keys[pkspec]
         subkey = PGPKey.new(*skspec)
@@ -465,8 +465,8 @@ class TestPGPKey_Management(object):
         if not alg.can_gen:
             pytest.xfail('Key algorithm {} not yet supported'.format(alg.name))
 
-        if isinstance(size, EllipticCurveOID) and ((not size.can_gen) or size.name not in _openssl_get_supported_curves()):
-            pytest.xfail('Curve {} not yet supported'.format(size.name))
+        if isinstance(size, EllipticCurveOID) and ((not size.can_gen) or size.curve.name not in _openssl_get_supported_curves()):
+            pytest.xfail('Curve {} not yet supported'.format(size.curve.name))
 
         # revoke the subkey
         key = self.keys[pkspec]


### PR DESCRIPTION
We were testing the wrong version of the curve string.  With this
change on python-cryptography 2.6.1 and openssl 1.1.1c, we drop from
26 xfailed to 14 xfailed tests.