### PR TITLE
Avoid warnings about bad escape characters

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -2476,7 +2476,7 @@ class PGPKeyring(collections.abc.Container, collections.abc.Iterable, collection
                 self._add_key(subkey)
 
     def load(self, *args):
-        """
+        r"""
         Load all keys provided into this keyring object.
 
         :param \*args: Each arg in ``args`` can be any of the formats supported by :py:meth:`PGPKey.from_path` and

--- a/tests/test_99_regressions.py
+++ b/tests/test_99_regressions.py
@@ -315,7 +315,7 @@ def test_pubkey_subkey_parent():
 
 cleartext_sigs = ['tests/testdata/messages/cleartext.oneline.signed.asc',
                   'tests/testdata/messages/cleartext.empty.signed.asc']
-cleartexts = ['This is stored, literally\!',
+cleartexts = [r'This is stored, literally\!',
               '']
 
 


### PR DESCRIPTION
Python strings don't use \ to escape either * or !.  So the
declarations here were adding to the list of warnings during the run
of the test suite.

Declaring them as raw (unescaped) strings keeps the warnings more quiet.

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>