### PR TITLE
ensure that ECPoint copy works for native points

### DIFF
--- a/pgpy/packet/fields.py
+++ b/pgpy/packet/fields.py
@@ -473,6 +473,7 @@ class ECPoint:
             self.x = MPI(MPIs.bytes_to_int(xy[:self.bytelen]))
             self.y = MPI(MPIs.bytes_to_int(xy[self.bytelen:]))
         elif self.format == ECPointFormat.Native:
+            self.bytelen = 0 # dummy value for copy
             self.x = bytes(xy)
             self.y = None
         else:


### PR DESCRIPTION
@rot42 noticed this first. it will affect the tests once we include native-formatted EC points in the test data.