### PR TITLE
Use dedicated exception class when ECPointFormat is wrong

### DIFF
--- a/pgpy/errors.py
+++ b/pgpy/errors.py
@@ -4,6 +4,7 @@
 __all__ = ('PGPError',
            'PGPEncryptionError',
            'PGPDecryptionError',
+           'PGPIncompatibleECPointFormat',
            'PGPOpenSSLCipherNotSupported',
            'PGPInsecureCipher',
            'WontImplementError',)
@@ -21,6 +22,11 @@ class PGPEncryptionError(Exception):
 
 class PGPDecryptionError(Exception):
     """Raised when decryption fails"""
+    pass
+
+
+class PGPIncompatibleECPointFormat(Exception):
+    """Raised when the point format is incompatible with the elliptic curve"""
     pass
 
 

--- a/pgpy/packet/fields.py
+++ b/pgpy/packet/fields.py
@@ -55,6 +55,7 @@ from ..decorators import sdproperty
 
 from ..errors import PGPDecryptionError
 from ..errors import PGPError
+from ..errors import PGPIncompatibleECPointFormat
 
 from ..symenc import _decrypt
 from ..symenc import _encrypt
@@ -565,8 +566,7 @@ class ECDSAPub(PubKey):
 
         self.p = ECPoint(packet)
         if self.p.format != ECPointFormat.Standard:
-            raise NotImplementedError("Expected: standard Elliptic curve point format (0x40). Got: 0x{:02X}".format(self.p.format))
-
+            raise PGPIncompatibleECPointFormat("Only Standard format is valid for ECDSA")
 
 
 class ECDHPub(PubKey):
@@ -637,7 +637,7 @@ class ECDHPub(PubKey):
 
         self.p = ECPoint(packet)
         if self.p.format != ECPointFormat.Standard:
-            raise NotImplementedError("Expected: standard Elliptic curve point format (0x40). Got: 0x{:02X}".format(self.p.format))
+            raise PGPIncompatibleECPointFormat("Only curves using Standard format are currently supported for ECDH")
         self.kdf.parse(packet)
 
 


### PR DESCRIPTION
This makes it easier to catch these specific types of errors if the
user wants to, and makes it clearer what is happening.