### PR TITLE
return the full UTF-8 string of the User ID

### DIFF
--- a/pgpy/packet/packets.py
+++ b/pgpy/packet/packets.py
@@ -1318,6 +1318,15 @@ class UserID(Packet):
         uid.email = self.email
         return uid
 
+    @property
+    def utf8(self):
+        _ret = self.name
+        if self.comment:
+            _ret += ' (' + self.comment + ')'
+        if self.email:
+            _ret += ' <' + self.email + '>'
+        return _ret
+
     def parse(self, packet):
         super(UserID, self).parse(packet)
 


### PR DESCRIPTION
Sometimes it's useful just to treat the UTF-8 User ID as a UTF-8 string, without parsing it into these fields.  Make it easier to do that.