### PR TITLE
Fix sphinx warnings about IDEA documentation

### DIFF
--- a/pgpy/constants.py
+++ b/pgpy/constants.py
@@ -160,8 +160,7 @@ class PacketTag(IntEnum):
 class SymmetricKeyAlgorithm(IntEnum):
     """Supported symmetric key algorithms."""
     Plaintext = 0x00
-    #: .. warning::
-    #:     IDEA is insecure. PGPy only allows it to be used for decryption, not encryption!
+    #: .. warning:: IDEA is insecure. PGPy only allows it to be used for decryption, not encryption!
     IDEA = 0x01
     #: Triple-DES with 168-bit key derived from 192
     TripleDES = 0x02


### PR DESCRIPTION
Without this change, the warning about IDEA is not properly rendered
in html, and ./setup.py build_sphinx itself produces a warning:

```
…/pgpy/constants.py:docstring of pgpy.constants.SymmetricKeyAlgorithm.IDEA:1: WARNING: Content block expected for the "warning" directive; none found.
…/pgpy/constants.py:docstring of pgpy.constants.SymmetricKeyAlgorithm.IDEA:2: WARNING: Explicit markup ends without a blank line; unexpected unindent.
```

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>