### PR TITLE
tests: avoid references to gpg.Context after deletion

### DIFF
--- a/tests/test_99_regressions.py
+++ b/tests/test_99_regressions.py
@@ -160,7 +160,7 @@ def test_reg_bug_56():
             gpg.core.gpgme.gpgme_op_import(c.wrapped, key_data)
 
             _, vres = c.verify(gpg.Data(string=sigsubject.decode('latin-1')), gpg.Data(string=str(sig)))
-        assert vres
+            assert vres
 
 
 @pytest.mark.regression(issue=157)


### PR DESCRIPTION
Some older versions of the python bindings for GPGME produce python
objects that reference the underlying gpg.Context objects.

When a gpg.Context is used in a "with" clause, it is disposed of at
the end, and any resulting objects that reference that context object
are dangling.

This doesn't seem to be a problem with gpgme 1.13.1 (the current
version), but i was seeing segfaults in the PGPy test suite when used
with gpgme 1.12.0 :(

These fixes should make PGPy's test suite more robust against this
kind of failure.

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>