### PR TITLE
User IDs: simplify, treat as UTF-8 strings

### DIFF
--- a/pgpy/packet/packets.py
+++ b/pgpy/packet/packets.py
@@ -1290,32 +1290,23 @@ class UserID(Packet):
     """
     __typeid__ = 0x0D
 
-    def __init__(self):
+    def __init__(self, uid=""):
         super(UserID, self).__init__()
-        self.name = ""
-        self.comment = ""
-        self.email = ""
+        self.uid = uid
         self._encoding_fallback = False
 
     def __bytearray__(self):
         _bytes = bytearray()
         _bytes += super(UserID, self).__bytearray__()
         textenc = 'utf-8' if not self._encoding_fallback else 'charmap'
-        _bytes += self.name.encode(textenc)
-        if self.comment:
-            _bytes += b' (' + self.comment.encode(textenc) + b')'
-
-        if self.email:
-            _bytes += b' <' + self.email.encode(textenc) + b'>'
+        _bytes += self.uid.encode(textenc)
 
         return _bytes
 
     def __copy__(self):
         uid = UserID()
         uid.header = copy.copy(self.header)
-        uid.name = self.name
-        uid.comment = self.comment
-        uid.email = self.email
+        uid.uid = self.uid
         return uid
 
     def parse(self, packet):
@@ -1325,30 +1316,10 @@ class UserID(Packet):
         # uid_text = packet[:self.header.length].decode('utf-8')
         del packet[:self.header.length]
         try:
-            uid_text = uid_bytes.decode('utf-8')
+            self.uid = uid_bytes.decode('utf-8')
         except UnicodeDecodeError:
-            uid_text = uid_bytes.decode('charmap')
+            self.uid = uid_bytes.decode('charmap')
             self._encoding_fallback = True
-
-        # came across a UID packet with no payload. If that happens, don't bother trying to parse anything!
-        if self.header.length > 0:
-            uid = re.match(r"""^
-                               # name should always match something
-                               (?P<name>.+?)
-                               # comment *optionally* matches text in parens following name
-                               # this should never come after email and must be followed immediately by
-                               # either the email field, or the end of the packet.
-                               (\ \((?P<comment>.+?)\)(?=(\ <|$)))?
-                               # email *optionally* matches text in angle brackets following name or comment
-                               # this should never come before a comment, if comment exists,
-                               # but can immediately follow name if comment does not exist
-                               (\ <(?P<email>.+)>)?
-                               $
-                            """, uid_text, flags=re.VERBOSE).groupdict()
-
-            self.name = uid['name']
-            self.comment = uid['comment'] or ""
-            self.email = uid['email'] or ""
 
 
 class PubSubKey(VersionedPacket, Sub, Public):


### PR DESCRIPTION
Over in #271, we discussed simplifying the lower-level UserID packet
object, and moving the <name,comment,email> splitting logic up into
the higher-layer PGPUID API.

This patch does that work, and also exposes an additional
PGPUID.userid property, which is the full UTF-8 string.

If this gets merged, it will obsolete #271.

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>