### PR TITLE
KeyServerPreferences is a bitfield, not a list

### DIFF
--- a/pgpy/constants.py
+++ b/pgpy/constants.py
@@ -433,8 +433,7 @@ class SignatureType(IntEnum):
     ThirdParty_Confirmation = 0x50
 
 
-class KeyServerPreferences(IntEnum):
-    Unknown = 0x00
+class KeyServerPreferences(FlagEnum):
     NoModify = 0x80
 
 

--- a/pgpy/packet/subpackets/signature.py
+++ b/pgpy/packet/subpackets/signature.py
@@ -690,7 +690,7 @@ class PreferredCompressionAlgorithms(FlagList):
     __flags__ = CompressionAlgorithm
 
 
-class KeyServerPreferences(FlagList):
+class KeyServerPreferences(ByteFlag):
     __typeid__ = 0x17
     __flags__ = _KeyServerPreferences
 

--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1927,6 +1927,8 @@ class PGPKey(Armorable, ParentRef, PGPObject):
         :keyword keyserver: Specify the URI of the preferred key server of the user.
                             This keyword is ignored for non-self-certifications.
         :type keyserver: ``str``, ``unicode``, ``bytes``
+        :keyword keyserver_flags: A set of Key Server Preferences, as :py:obj:`~constants.KeyServerPreferences`.
+        :type keyserver_flags: ``set``
         :keyword primary: Whether or not to consider the certified User ID as the primary one.
                           This keyword is ignored for non-self-certifications, and any certifications directly on keys.
         :type primary: ``bool``

--- a/tests/test_05_actions.py
+++ b/tests/test_05_actions.py
@@ -335,7 +335,7 @@ class TestPGPKey_Management(object):
                         hashes=[HashAlgorithm.SHA384],
                         compression=[CompressionAlgorithm.ZLIB],
                         key_expiration=expiration,
-                        keyserver_flags=0x80,
+                        keyserver_flags={KeyServerPreferences.NoModify},
                         keyserver='about:none',
                         primary=False)
 
@@ -348,7 +348,7 @@ class TestPGPKey_Management(object):
         assert sig.features == {Features.ModificationDetection}
         assert sig.key_expiration == expiration - key.created
         assert sig.keyserver == 'about:none'
-        assert sig.keyserverprefs == [KeyServerPreferences.NoModify]
+        assert sig.keyserverprefs == {KeyServerPreferences.NoModify}
 
         assert uid.is_primary is False
 


### PR DESCRIPTION
Key Server Preferences (RFC 4880 §5.2.3.17) is a bitfield, more like
Key Flags (RFC 4880 §5.2.3.21) than Preferred Hash Algorithms (RFC
4880 §5.2.3.8).

The caller should be able to invoke this as a set when calling
PGPKey.certify().

This patch also improves documentation for PGPKey.certify() to
indicate how to pass in these flags.

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>