### PR TITLE
PGPKey.certify: document exportable flag

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1943,6 +1943,8 @@ class PGPKey(Armorable, ParentRef, PGPObject):
                         this regular expression.
                         This is meaningless without also specifying trust level and amount.
         :type regex: ``str``
+        :keyword exportable: Whether this certification is exportable or not.
+        :type exportable: ``bool``
         """
         hash_algo = prefs.pop('hash', None)
         sig_type = level


### PR DESCRIPTION
The exportable flag is already implemented, but it is not documented
in the docstring.  This addresses that concern.

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>