### PR TITLE
When Signature Creation Time is supplied, use UTC

### DIFF
--- a/pgpy/packet/subpackets/signature.py
+++ b/pgpy/packet/subpackets/signature.py
@@ -242,7 +242,7 @@ class CreationTime(Signature):
 
     def __bytearray__(self):
         _bytes = super(CreationTime, self).__bytearray__()
-        _bytes += self.int_to_bytes(calendar.timegm(self.created.timetuple()), 4)
+        _bytes += self.int_to_bytes(calendar.timegm(self.created.utctimetuple()), 4)
         return _bytes
 
     def parse(self, packet):


### PR DESCRIPTION
When the Signature Creation Time was supplied to the signing function,
we were ignoring the fact that it might have a different timezone than
UTC.  But the stored timestamp is supposed to always be in UTC, so it
should roundtrip correctly.

This includes a test to ensure that we don't end up with a regression.

Closes: #291