### PR TITLE
Avoid noisy warnings when generating messages

### DIFF
--- a/pgpy/decorators.py
+++ b/pgpy/decorators.py
@@ -3,7 +3,7 @@
 import contextlib
 import functools
 import six
-import warnings
+import logging
 
 try:
     from singledispatch import singledispatch
@@ -100,7 +100,7 @@ class KeyAction(object):
 
         if _key is not key:
             em['subkeyid'] = _key.fingerprint.keyid
-            warnings.warn("Key {keyid:s} does not have the required usage flag {flags:s}; using subkey {subkeyid:s}"
+            logging.debug("Key {keyid:s} does not have the required usage flag {flags:s}; using subkey {subkeyid:s}"
                           "".format(**em), stacklevel=4)
 
         yield _key


### PR DESCRIPTION
Similar to the concerns in #297, there are noisy warnings produced
when encrypting data to or signing data with a primary key, if a
subkey is ultimately what ends up being used:

```
./generate-test-vectors:279: UserWarning: Key F231550C4F47E38E does not have the required usage flag EncryptStorage, EncryptCommunications; using subkey 4766F6B9D5F21EB6
  encmsg = alice_key.pubkey.encrypt(payloadmsg, cipher=cipher, sessionkey=sessionkey)
```

This change converts these warnings to debug information.

In #298, we just removed the noisy warnings on consuming data -- the
caller really has no choice in how to consume the data, so there's no
point in sending them alerts.  Either we can decrypt or verify with
the primary key or one of the subkeys, or we can't.

But in the situation where the caller is producing data -- signing or
encrypting -- we might want be a little bit noisier, because the user
really might have some obscure reason that they prefer to use a
specific subkey that the library isn't in a position to understand.
So giving the user a hint at debug-level about what's going on is
probably reasonable.

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>