### PR TITLE
Fix comment to align with example

### DIFF
--- a/docs/source/examples/keys.rst
+++ b/docs/source/examples/keys.rst
@@ -32,7 +32,7 @@ using a :py:obj:`datetime.datetime` or a :py:obj:`datetime.timedelta` object::
 
     from datetime import timedelta
 
-    # in this example, we'll use fewer preferences for the sake of brevity, and set the key to expire in 10 years
+    # in this example, we'll use fewer preferences for the sake of brevity, and set the key to expire in 1 year
     key = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 4096)
     uid = pgpy.PGPUID.new('Nikola Tesla')  # comment and email are optional
 


### PR DESCRIPTION
The example code sets the key to expire in one year using timedelta(days=365), although the leading comment implies it will be set to ten years.