### PR TITLE
Update and fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
   - ./install_dependencies.${TRAVIS_OS_NAME}.sh
   # ensure tox and coveralls are installed. pin PyYAML until we drop Python 3.4
-  - pip install tox python-coveralls PyYAML==5.2
+  - pip install tox python-coveralls 'PyYAML==5.2; python_version == "3.4"'
 
 # set TOXENV if it isn't yet
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 os:
   - linux
-  - osx
+  # - osx
 sudo: required
 language: python
 python:
@@ -48,7 +48,7 @@ matrix:
     - python: "pypy"
     - python: "pypy3"
     # osx, until it's working
-    - os: osx
+    # - os: osx
 
 # install requirements
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 os:
   - linux
   # - osx
-sudo: required
 language: python
 python:
   - "3.7"
@@ -12,7 +11,7 @@ python:
   - "2.7"
   - "pypy"
   - "pypy3"
-matrix:
+jobs:
   include:
     # add a pep8 test
     - python: 3.6

--- a/install_dependencies.linux.sh
+++ b/install_dependencies.linux.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-sudo apt-get update
-sudo apt-get install -y libffi-dev gnupg2
+sudo apt-get -y update
+sudo apt-get -y install libffi-dev gnupg2
 
 if [ -z "${TOXENV}" ]; then
-    sudo apt-get install gpgsm libassuan-dev libgpg-error-dev swig
+    sudo apt-get -y install gpgsm libassuan-dev libgpg-error-dev swig
 
     # build/install gpgme 1.8.0 manually
     wget https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-1.7.0.tar.bz2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 import glob
 try:
     import gpg
-except (ModuleNotFoundError, NameError):
+except ImportError:
     gpg = None
 import os
 import sys

--- a/tests/test_05_actions.py
+++ b/tests/test_05_actions.py
@@ -8,7 +8,7 @@ import copy
 import glob
 try:
     import gpg
-except (ModuleNotFoundError, NameError):
+except ImportError:
     gpg = None
 import itertools
 import os

--- a/tests/test_99_regressions.py
+++ b/tests/test_99_regressions.py
@@ -4,7 +4,7 @@ from conftest import gpg_ver, gnupghome
 
 try:
     import gpg
-except (ModuleNotFoundError, NameError):
+except ImportError:
     gpg = None
 import os
 import datetime

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv = HOME ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH PATH
 deps =
     cryptography>=2.6
     enum34
-    gpg==1.8.0
+    gpg==1.10.0
     pyasn1
     six>=1.9.0
     singledispatch

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ whitelist_externals = {[test-setup]whitelist_externals}
 commands = {[test-setup]commands}
 
 [testenv:pep8]
-basepython = python3.7
+basepython = python3.6
 deps =
     flake8
     pep8-naming


### PR DESCRIPTION
- Fixed PEP8 test so it actually runs
- Updated `.travis.yml` to latest standard
- Made sure `install_dependencies.linux.sh` can be run without input
- Disabled OSX tests to reduce run time and visual noise
- Fixed import try/except so pypy test runs
- Updated `gpg` to 1.10.0 so pypy3 test runs
- Pin PyYAML to 5.2 only for Python 3.4