### PR TITLE
Support keys with private/experimental hash algorithms

### DIFF
--- a/pgpy/constants.py
+++ b/pgpy/constants.py
@@ -339,6 +339,17 @@ class HashAlgorithm(IntEnum):
     SHA384 = 0x09
     SHA512 = 0x0A
     SHA224 = 0x0B
+    _private_experimental_00 = 0x64
+    _private_experimental_01 = 0x65
+    _private_experimental_02 = 0x66
+    _private_experimental_03 = 0x67
+    _private_experimental_04 = 0x68
+    _private_experimental_05 = 0x69
+    _private_experimental_06 = 0x6A
+    _private_experimental_07 = 0x6B
+    _private_experimental_08 = 0x6C
+    _private_experimental_09 = 0x6D
+    _private_experimental_10 = 0x6E
 
     def __init__(self, *args):
         super(self.__class__, self).__init__()


### PR DESCRIPTION
This PR adds private/experimental hash algorithm IDs so keys using these do not fail at importing