### PR TITLE
Fix dash un-escaping to be applied unconditionally

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -844,7 +844,7 @@ class PGPUID(ParentRef):
 class PGPMessage(Armorable, PGPObject):
     @staticmethod
     def dash_unescape(text):
-        return re.subn(r'^- -', '-', text, flags=re.MULTILINE)[0]
+        return re.subn(r'^- ', '', text, flags=re.MULTILINE)[0]
 
     @staticmethod
     def dash_escape(text):

--- a/tests/test_99_regressions.py
+++ b/tests/test_99_regressions.py
@@ -428,3 +428,36 @@ Pnn+We1aTBhaGa86AQ==
     roundtrip = PGPSignature.from_blob(str(pgpsig))
 
     assert pgpsig.created.utctimetuple() == roundtrip.created.utctimetuple()
+
+
+@pytest.mark.regression(issue=341)
+def test_spurious_dash_escapes():
+    from pgpy import PGPKey, PGPMessage
+
+    message_data = r'''-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1,SHA256
+
+- This is stored, literally\!
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG/MacGPG2 v2.0.20 (Darwin)
+
+iJwEAQECAAYFAlQaCpEACgkQBM3VPIdAqKYrhwQAyQhwiqrR6oZ5fTBm4JyCOEND
+72Kxbaz1i9Qh0jv7DmgRjb4udh95UQ8U0qVnmnhA8E2deKeDcWTS4fzUkU6J9OdH
+/GPHpL9QEtOJ7xifzJsnKaNJVynmNMtYOqHQ9gCmXx7jM2ngxbTKBT8YZlSLMUdO
+uoUFKrJGv0LWlSWHkeOJARwEAQECAAYFAlQaCpEACgkQKoNNjlkY6IYrhwf/ZnMN
+yKIVxGl+5/9oovvgz2MtGt9B09xRg4BqD+lUDshzQUvQIjBXZ7ZEGSWqerRymZDg
+ZzHpb1lv9oAOVU8f1qsMQJJkiz7Q+xu5FfgAp0WzMHJNy4QOmB4Kw/7UbTwdUXzw
+EzKwbJ8Eg97vJgYdfqUZLu949dwJvyYZzGDdkbrnsaZ8H29XkKXNMlMinDQjvFBR
+djgkILl3ZIdC3p+KechV3uYsqwje2qNEo69KukihPhzCe9o6/Yub5gdC+DSQDGl4
+uPjk0zXjds4G5J5Jd5g4o7vhDWs8InxX4AcLfD6lH1XQ1VCZBpucun5CVsU3dUAv
+yvO7C7FubDu1GUxdbYheBAERCAAGBQJUGgqRAAoJEKXc3JZkUxQOZ+IA/3KI8Mnl
+k3jfpRQcvtSYFlU9WZk9SqZX6xirnV7Hloq6AP9ZlivPrJdWmjRyyShkMNgP/c63
+cjMX82ahGPUVlyMP4A==
+=bcSu
+-----END PGP SIGNATURE-----
+'''
+
+    key = PGPKey.from_file('tests/testdata/keys/rsa.1.pub.asc')[0]
+    message = PGPMessage.from_blob(message_data)
+    assert key.verify(message)


### PR DESCRIPTION
According to RFC 4880, 'an implementation MAY dash-escape any line,
SHOULD dash-escape lines commencing "From" followed by a space [...]'.
Therefore it is necessary to unescape all lines starting with dash-space
sequences, and not just these that have a dash following this sequence.

Fixes #341