### PR TITLE
Added the PGP.Message API call to docs

### DIFF
--- a/docs/source/api/classes.rst
+++ b/docs/source/api/classes.rst
@@ -43,7 +43,6 @@ Classes
                     key, others = PGPKey.from_file('path/to/keyfile')
                     # others: { (Fingerprint, bool(key.is_public)): PGPKey }
 
-
 :py:class:`PGPKeyring`
 ----------------------
 
@@ -86,6 +85,8 @@ Classes
         :raises: :py:exc:`~exceptions.PGPError` if de-armoring or parsing failed
         :returns: :py:obj:`PGPMessage`
 
+    .. py:attribute:: message
+        Get the original message of the PGPMessage. If it's compressed than decompress it. The message must be decrypted. Removes any headers.
 
 :py:class:`PGPSignature`
 ------------------------

--- a/docs/source/examples/actions.rst
+++ b/docs/source/examples/actions.rst
@@ -118,5 +118,5 @@ someone else's public key. That can be done like so::
     # enc_message.is_encrypted is True
     # a message that was encrypted using a passphrase can also be decrypted using
     # that same passphrase
-    dec_message = enc_message.decrypt("S00per_Sekr3t")
+    dec_message = enc_message.decrypt("S00per_Sekr3t").message
 

--- a/docs/source/examples/messages.rst
+++ b/docs/source/examples/messages.rst
@@ -30,8 +30,8 @@ Existing messages can also be loaded very simply. This is nearly identical to lo
 it only returns the new message object, instead of a tuple::
 
     # PGPMessage will automatically determine if this is a cleartext message or not
-    message_from_file = pgpy.PGPMessage.from_file("path/to/a/message")
-    message_from_blob = pgpy.PGPMessage.from_blob(msg_blob)
+    message_from_file = pgpy.PGPMessage.from_file("path/to/a/message").message
+    message_from_blob = pgpy.PGPMessage.from_blob(msg_blob).message
 
 Exporting Messages
 ------------------

--- a/pgpy/_author.py
+++ b/pgpy/_author.py
@@ -15,4 +15,4 @@ __all__ = ['__author__',
 __author__ = "Michael Greene"
 __copyright__ = "Copyright (c) 2014-2019 Security Innovation, Inc"
 __license__ = "BSD"
-__version__ = str(LooseVersion("0.6.0-dev"))
+__version__ = str(LooseVersion("0.6.1-dev"))

--- a/pgpy/constants.py
+++ b/pgpy/constants.py
@@ -352,6 +352,17 @@ class HashAlgorithm(IntEnum):
     SHA384 = 0x09
     SHA512 = 0x0A
     SHA224 = 0x0B
+    _private_experimental_00 = 0x64
+    _private_experimental_01 = 0x65
+    _private_experimental_02 = 0x66
+    _private_experimental_03 = 0x67
+    _private_experimental_04 = 0x68
+    _private_experimental_05 = 0x69
+    _private_experimental_06 = 0x6A
+    _private_experimental_07 = 0x6B
+    _private_experimental_08 = 0x6C
+    _private_experimental_09 = 0x6D
+    _private_experimental_10 = 0x6E
 
     def __init__(self, *args):
         super(self.__class__, self).__init__()

--- a/pgpy/constants.py
+++ b/pgpy/constants.py
@@ -6,6 +6,7 @@ import imghdr
 import os
 import time
 import zlib
+import lzma
 
 from collections import namedtuple
 from enum import Enum
@@ -294,6 +295,8 @@ class CompressionAlgorithm(IntEnum):
     ZLIB = 0x02
     #: Bzip2
     BZ2 = 0x03
+	#: LZMA
+    XZ = 0x04
 
     def compress(self, data):
         if self is CompressionAlgorithm.Uncompressed:
@@ -307,6 +310,9 @@ class CompressionAlgorithm(IntEnum):
 
         if self is CompressionAlgorithm.BZ2:
             return bz2.compress(data)
+
+        if self is CompressionAlgorithm.XZ:
+            return lzma.compress(data, filters=[{'id': lzma.FILTER_LZMA2, 'preset': 9 | lzma.PRESET_EXTREME}])
 
         raise NotImplementedError(self)
 
@@ -325,6 +331,9 @@ class CompressionAlgorithm(IntEnum):
 
         if self is CompressionAlgorithm.BZ2:
             return bz2.decompress(data)
+
+        if self is CompressionAlgorithm.XZ:
+            return lzma.decompress(data)
 
         raise NotImplementedError(self)
 

--- a/pgpy/packet/fields.py
+++ b/pgpy/packet/fields.py
@@ -11,11 +11,6 @@ import itertools
 import math
 import os
 
-try:
-    import collections.abc as collections_abc
-except ImportError:
-    collections_abc = collections
-
 from pyasn1.codec.der import decoder
 from pyasn1.codec.der import encoder
 from pyasn1.type.univ import Integer
@@ -103,7 +98,7 @@ __all__ = ['SubPackets',
            'ECDHCipherText', ]
 
 
-class SubPackets(collections_abc.MutableMapping, Field):
+class SubPackets(collections.MutableMapping, Field):
     _spmodule = signature
 
     def __init__(self):

--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1111,7 +1111,7 @@ class PGPMessage(Armorable, PGPObject):
         cleartext = kwargs.pop('cleartext', False)
         format = kwargs.pop('format', None)
         sensitive = kwargs.pop('sensitive', False)
-        compression = kwargs.pop('compression', CompressionAlgorithm.ZIP)
+        compression = kwargs.pop('compression', CompressionAlgorithm.XZ)
         file = kwargs.pop('file', False)
         charset = kwargs.pop('encoding', None)
 


### PR DESCRIPTION
Added the undocumented .message API call to the documentation, as it's essential for reading compressed and encrypted messages (since encrypted messages are currently required to be compressed), as well as automatically removing PGP headers. 