### PR TITLE
Added PGP.message to docs

### DIFF
--- a/docs/source/api/classes.rst
+++ b/docs/source/api/classes.rst
@@ -43,7 +43,6 @@ Classes
                     key, others = PGPKey.from_file('path/to/keyfile')
                     # others: { (Fingerprint, bool(key.is_public)): PGPKey }
 
-
 :py:class:`PGPKeyring`
 ----------------------
 
@@ -86,6 +85,8 @@ Classes
         :raises: :py:exc:`~exceptions.PGPError` if de-armoring or parsing failed
         :returns: :py:obj:`PGPMessage`
 
+    .. py:attribute:: message
+        Get the original message of the PGPMessage. If it's compressed than decompress it. The message must be decrypted. Removes any headers.
 
 :py:class:`PGPSignature`
 ------------------------

--- a/docs/source/examples/actions.rst
+++ b/docs/source/examples/actions.rst
@@ -118,5 +118,5 @@ someone else's public key. That can be done like so::
     # enc_message.is_encrypted is True
     # a message that was encrypted using a passphrase can also be decrypted using
     # that same passphrase
-    dec_message = enc_message.decrypt("S00per_Sekr3t")
+    dec_message = enc_message.decrypt("S00per_Sekr3t").message
 

--- a/docs/source/examples/messages.rst
+++ b/docs/source/examples/messages.rst
@@ -30,8 +30,8 @@ Existing messages can also be loaded very simply. This is nearly identical to lo
 it only returns the new message object, instead of a tuple::
 
     # PGPMessage will automatically determine if this is a cleartext message or not
-    message_from_file = pgpy.PGPMessage.from_file("path/to/a/message")
-    message_from_blob = pgpy.PGPMessage.from_blob(msg_blob)
+    message_from_file = pgpy.PGPMessage.from_file("path/to/a/message").message
+    message_from_blob = pgpy.PGPMessage.from_blob(msg_blob).message
 
 Exporting Messages
 ------------------


### PR DESCRIPTION
Added the undocumented .message API call to the documentation, as it's essential for reading compressed and encrypted messages (since encrypted messages are currently required to be compressed), as well as automatically removing PGP headers.