### PR TITLE
Use GitHub Actions as primary CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: run-tox
-on: [push]
+on: [push, pull_request]
 jobs:
   unit-tests:
     runs-on: ubuntu-16.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,19 +21,6 @@ jobs:
       - name: Run Tox
         run: tox -e py
 
-  pep8:
-    runs-on: ubuntu-16.04
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
-      - name: Install tox
-        run: pip install tox
-      - name: Run tox
-        run: tox -e pep8
-
   test-setup:
     runs-on: ubuntu-16.04
     strategy:
@@ -58,3 +45,16 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox -e ${{ matrix.env }}
+
+  pep8:
+    runs-on: ubuntu-16.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install tox
+        run: pip install tox
+      - name: Run tox
+        run: tox -e pep8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: run-tox
+name: Tox Tests
 on: [push, pull_request]
 jobs:
   unit-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,3 +31,26 @@ jobs:
           python-version: 3.6
       - run: pip install tox
       - run: tox -e pep8
+
+  test-setup:
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        include:
+          - python-version: 3.5
+            env: setup35
+          - python-version: 3.6
+            env: setup36
+          - python-version: 3.7
+            env: setup37
+          - python-version: 3.8
+            env: setup38
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - run: tox -e ${{ matrix.env }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements
         run: |
-        sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
-        ./install_dependencies.linux.sh
-        pip install tox python-coveralls
+          sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
+          ./install_dependencies.linux.sh
+          pip install tox python-coveralls
       - name: Run Tox
         run: tox -e py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
 
   pep8:
     runs-on: ubuntu-16.04
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,12 @@ jobs:
           pip install tox python-coveralls
       - name: Run Tox
         run: tox -e py
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: run-${{ matrix.python-version }}
+          parallel: true
 
   test-setup:
     runs-on: ubuntu-16.04
@@ -60,3 +66,13 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox -e pep8
+
+  finish:
+    needs: unit-tests
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install requirements
         run: |
           sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
-          [ "$(uname)" = "Darwin" ] && ./install_dependencies.osx.sh || ./install_dependencies.linux.sh
+          if [ "$(uname)" = "Darwin" ]; then ./install_dependencies.osx.sh; else ./install_dependencies.linux.sh; fi
           pip install tox
       - name: Run Tox
         run: ./tox.sh -e py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,14 @@ on: [push]
 jobs:
   unit-tests:
     runs-on: ubuntu-16.04
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        allow_failure: [false]
+        include:
+          - python-version: pypy3
+            allow_failure: true
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install requirements
         run: |
           sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
-          [ $(uname) = "Darwin"] && ./install_dependencies.osx.sh || ./install_dependencies.linux.sh
+          [ "$(uname)" = "Darwin" ] && ./install_dependencies.osx.sh || ./install_dependencies.linux.sh
           pip install tox
       - name: Run Tox
         run: ./tox.sh -e py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.6
+      - run: pip install tox
       - run: tox -e pep8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.6
-      - run: pip install tox
-      - run: tox -e pep8
+      - name: Install tox
+        run: pip install tox
+      - name: Run tox
+        run: tox -e pep8
 
   test-setup:
     runs-on: ubuntu-16.04
@@ -52,5 +54,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install tox
-      - run: tox -e ${{ matrix.env }}
+      - name: Install tox
+        run: pip install tox
+      - name: Run tox
+        run: tox -e ${{ matrix.env }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,15 +17,9 @@ jobs:
         run: |
           sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
           ./install_dependencies.linux.sh
-          pip install tox python-coveralls
+          pip install tox
       - name: Run Tox
         run: tox -e py
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@v1.1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: run-${{ matrix.python-version }}
-          parallel: true
 
   test-setup:
     runs-on: ubuntu-16.04
@@ -67,12 +61,3 @@ jobs:
       - name: Run tox
         run: tox -e pep8
 
-  finish:
-    needs: unit-tests
-    runs-on: ubuntu-16.04
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@v1.1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: run-tox
+on: [push]
+jobs:
+  unit-tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install requirements
+        run: |
+        sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
+        ./install_dependencies.linux.sh
+        pip install tox python-coveralls
+      - name: Run Tox
+        run: tox -e py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,15 +18,21 @@ jobs:
         run: |
           sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
           if [ "$(uname)" = "Darwin" ]; then ./install_dependencies.osx.sh; else ./install_dependencies.linux.sh; fi
-          pip install tox
+          pip install tox coveralls
       - name: Run Tox
         run: ./tox.sh -e py
+      - name: Upload Coveralls coverage
+        if: ${{ success() }}
+        run: coveralls
+        env:
+          COVERALLS_PARALLEL: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   c-locale-test:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
@@ -34,11 +40,17 @@ jobs:
         run: |
           sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
           ./install_dependencies.linux.sh
-          pip install tox
+          pip install tox coveralls
       - name: Run Tox
         run: ./tox.sh -e py
         env:
           LC_ALL: C
+      - name: Upload Coveralls coverage
+        if: ${{ success() }}
+        run: coveralls
+        env:
+          COVERALLS_PARALLEL: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-setup:
     runs-on: ubuntu-16.04
@@ -80,3 +92,17 @@ jobs:
       - name: Run tox
         run: tox -e pep8
 
+  finish-coveralls:
+    needs: [ unit-tests, c-locale-test ]
+    runs-on: ubuntu-16.04
+
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Finish Coveralls
+        run: |
+          pip install coveralls
+          coveralls --finish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,3 +20,12 @@ jobs:
           pip install tox python-coveralls
       - name: Run Tox
         run: tox -e py
+
+  pep8:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - run: tox -e pep8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,15 +27,15 @@ jobs:
       matrix:
         include:
           - python-version: 3.5
-            env: setup35
+            env: py35-setup
           - python-version: 3.6
-            env: setup36
+            env: py36-setup
           - python-version: 3.7
-            env: setup37
+            env: py37-setup
           - python-version: 3.8
-            env: setup38
+            env: py38-setup
           - python-version: 3.9
-            env: setup39
+            env: py39-setup
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,8 @@ jobs:
             env: setup37
           - python-version: 3.8
             env: setup38
+          - python-version: 3.9
+            env: setup39
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,24 @@ jobs:
       - name: Run Tox
         run: ./tox.sh -e py
 
+  c-locale-test:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install requirements
+        run: |
+          sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
+          ./install_dependencies.linux.sh
+          pip install tox
+      - name: Run Tox
+        run: ./tox.sh -e py
+        env:
+          LC_ALL: C
+
   test-setup:
     runs-on: ubuntu-16.04
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,10 @@ name: run-tox
 on: [push]
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,14 +3,9 @@ on: [push]
 jobs:
   unit-tests:
     runs-on: ubuntu-16.04
-    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
-        allow_failure: [false]
-        include:
-          - python-version: pypy3
-            allow_failure: true
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
           COVERALLS_PARALLEL: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # do some tests with LC_ALL=C to check for locale variance
   c-locale-test:
     runs-on: ubuntu-16.04
     steps:
@@ -52,6 +53,7 @@ jobs:
           COVERALLS_PARALLEL: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # test setup.py using each tested version
   test-setup:
     runs-on: ubuntu-16.04
     strategy:
@@ -79,9 +81,10 @@ jobs:
       - name: Run tox
         run: tox -e ${{ matrix.env }}
 
+  # add a pep8 test
   pep8:
     runs-on: ubuntu-16.04
-    continue-on-error: true
+    continue-on-error: true # pep8 failures shouldn't be considered fatal
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -92,6 +95,7 @@ jobs:
       - name: Run tox
         run: tox -e pep8
 
+  # report coverage to coveralls, but only for pytest runs
   finish-coveralls:
     needs: [ unit-tests, c-locale-test ]
     runs-on: ubuntu-16.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,10 @@ name: run-tox
 on: [push, pull_request]
 jobs:
   unit-tests:
-    runs-on: ubuntu-16.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-16.04, macos-10.15]
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
@@ -16,10 +17,10 @@ jobs:
       - name: Install requirements
         run: |
           sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
-          ./install_dependencies.linux.sh
+          [ $(uname) = "Darwin"] && ./install_dependencies.osx.sh || ./install_dependencies.linux.sh
           pip install tox
       - name: Run Tox
-        run: tox -e py
+        run: ./tox.sh -e py
 
   test-setup:
     runs-on: ubuntu-16.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,16 @@ jobs:
 
     # test setup.py using each tested version
     - python: 3.8
-      env: TOXENV=setup38
+      env: TOXENV=py38-setup
 
     - python: 3.7
-      env: TOXENV=setup37
+      env: TOXENV=py37-setup
 
     - python: 3.6
-      env: TOXENV=setup36
+      env: TOXENV=py36-setup
 
     - python: 3.5
-      env: TOXENV=setup35
+      env: TOXENV=py35-setup
 
     # do some tests with LC_ALL=C to check for locale variance
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
   - ./install_dependencies.${TRAVIS_OS_NAME}.sh
   # ensure tox and coveralls are installed
-  - pip install tox python-coveralls
+  - pip install tox coveralls
 
 # set TOXENV if it isn't yet
 before_script:
@@ -61,4 +61,4 @@ script:
 
 # and report coverage to coveralls, but only if this was a pytest run
 after_success:
-  - if [[ "${TOXENV}" == "py"* ]]; then coveralls; fi
+  - if [[ "${TOXENV}" == "py"* ]]; then coveralls debug; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
   - ./install_dependencies.${TRAVIS_OS_NAME}.sh
   # ensure tox and coveralls are installed
-  - pip install tox coveralls
+  - pip install tox
 
 # set TOXENV if it isn't yet
 before_script:
@@ -57,7 +57,3 @@ before_script:
 # run tox
 script:
   - ./tox.sh
-
-# and report coverage to coveralls, but only if this was a pytest run
-after_success:
-  - if [[ "${TOXENV}" == "py"* ]]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
   - "3.7"
   - "3.6"
   - "3.5"
-  - "pypy"
   - "pypy3"
 jobs:
   include:
@@ -61,4 +60,4 @@ script:
 
 # and report coverage to coveralls, but only if this was a pytest run
 after_success:
-  - if [[ "${TOXENV}" == "py"* ]]; then coveralls debug; fi
+  - if [[ "${TOXENV}" == "py"* ]]; then coveralls; fi

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,6 @@
+brew "libffi"
+brew "gnupg2"
+brew "pgpdump"
+brew "openssl@1.1"
+brew "gpgme"
+brew "swig"

--- a/install_dependencies.osx.sh
+++ b/install_dependencies.osx.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+brew unlink python@3.9 && brew link --overwrite python@3.9
 brew update 1>/dev/null
 brew install -q libffi gnupg2 pgpdump openssl@1.1 gpgme swig

--- a/install_dependencies.osx.sh
+++ b/install_dependencies.osx.sh
@@ -1,22 +1,4 @@
 #!/bin/bash
-# mapping to get from the TRAVIS_PYTHON_VERSION environment variable to something pyenv understands
-# this will need to be manually kept up to date until travis support for python on osx improves
-declare -A pyver
-pyver["2.7"]="2.7.13"
-pyver["3.4"]="3.4.6"
-pyver["3.5"]="3.5.3"
-pyver["3.6"]="3.6.0"
-pyver["3.7"]="3.7.0"
-pyver["pypy"]="pypy2-5.6.0"
-pyver["pypy3"]="pypy3.3-5.5-alpha"
 
-sudo brew update
-# travis doesn't natively support python on osx yet, so start by installing pyenv
-# also install newer openssl here
-sudo brew install -y pyenv openssl
-# now install the requested version of python, and set it to local
-pyenv install ${pyver[${TRAVIS_PYTHON_VERSION}]}
-pyenv local ${pyver[${TRAVIS_PYTHON_VERSION}]}
-
-# make sure libffi-dev, gnupg2, pgpdump, and newer openssl are installed as well
-sudo brew install -y libffi-dev gnupg2 pgpdump
+brew update
+brew install -y libffi-dev gnupg2 pgpdump openssl@1.1

--- a/install_dependencies.osx.sh
+++ b/install_dependencies.osx.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 brew update
-brew install -y libffi-dev gnupg2 pgpdump openssl@1.1
+brew install -y libffi-dev gnupg2 pgpdump openssl@1.1 gpgme

--- a/install_dependencies.osx.sh
+++ b/install_dependencies.osx.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 brew update
-brew install -y libffi-dev gnupg2 pgpdump openssl@1.1 gpgme
+brew install libffi-dev gnupg2 pgpdump openssl@1.1 gpgme

--- a/install_dependencies.osx.sh
+++ b/install_dependencies.osx.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 brew update 1>/dev/null
-brew install libffi gnupg2 pgpdump openssl@1.1 gpgme
+brew install -q libffi gnupg2 pgpdump openssl@1.1 gpgme swig

--- a/install_dependencies.osx.sh
+++ b/install_dependencies.osx.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 brew unlink python@3.9 && brew link --overwrite python@3.9
-brew update 1>/dev/null
-brew install -q libffi gnupg2 pgpdump openssl@1.1 gpgme swig
+brew bundle install

--- a/install_dependencies.osx.sh
+++ b/install_dependencies.osx.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-brew update
-brew install libffi-dev gnupg2 pgpdump openssl@1.1 gpgme
+brew update 1>/dev/null
+brew install libffi gnupg2 pgpdump openssl@1.1 gpgme

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy, pypy3, py35, py36, py37, py38, pep8, setup38, setup37, setup36, setup35
+envlist = py{35,36,37,38}, setup{35,36,37,38}, pypy3, pep8
 skipsdist = True
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38}, setup{35,36,37,38}, pypy3, pep8
+envlist = py{35,36,37,38,39}, setup{35,36,37,38,39}, pypy3, pep8
 skipsdist = True
 
 [pytest]
@@ -37,6 +37,13 @@ deps =
 commands =
     pip install -e .
     rm -rf PGPy.egg-info
+
+[testenv:setup39]
+recreate = True
+basepython = python3.9
+allowlist_externals = {[test-setup]allowlist_externals}
+deps =
+commands = {[test-setup]commands}
 
 [testenv:setup38]
 recreate = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39}, setup{35,36,37,38,39}, pypy3, pep8
+envlist = py{35,36,37,38,39}, py{35,36,37,38,39}-setup, pypy3, pep8
 skipsdist = True
 
 [pytest]
@@ -29,7 +29,8 @@ install_command = pip install {opts} --no-cache-dir {packages}
 commands =
     py.test --cov pgpy --cov-report term-missing tests/
 
-[test-setup]
+[testenv:py{35,36,37,38,39}-setup]
+recreate = True
 allowlist_externals =
     /usr/bin/rm
     /bin/rm
@@ -37,41 +38,6 @@ deps =
 commands =
     pip install -e .
     rm -rf PGPy.egg-info
-
-[testenv:setup39]
-recreate = True
-basepython = python3.9
-allowlist_externals = {[test-setup]allowlist_externals}
-deps =
-commands = {[test-setup]commands}
-
-[testenv:setup38]
-recreate = True
-basepython = python3.8
-allowlist_externals = {[test-setup]allowlist_externals}
-deps =
-commands = {[test-setup]commands}
-
-[testenv:setup37]
-recreate = True
-basepython = python3.7
-allowlist_externals = {[test-setup]allowlist_externals}
-deps =
-commands = {[test-setup]commands}
-
-[testenv:setup36]
-recreate = True
-basepython = python3.6
-allowlist_externals = {[test-setup]allowlist_externals}
-deps =
-commands = {[test-setup]commands}
-
-[testenv:setup35]
-recreate = True
-basepython = python3.5
-allowlist_externals = {[test-setup]allowlist_externals}
-deps =
-commands = {[test-setup]commands}
 
 [testenv:pep8]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,9 @@ commands =
     py.test --cov pgpy --cov-report term-missing tests/
 
 [test-setup]
-whitelist_externals = /usr/bin/rm
+allowlist_externals =
+    /usr/bin/rm
+    /bin/rm
 deps =
 commands =
     pip install -e .
@@ -39,28 +41,28 @@ commands =
 [testenv:setup38]
 recreate = True
 basepython = python3.8
-whitelist_externals = {[test-setup]whitelist_externals}
+allowlist_externals = {[test-setup]allowlist_externals}
 deps =
 commands = {[test-setup]commands}
 
 [testenv:setup37]
 recreate = True
 basepython = python3.7
-whitelist_externals = {[test-setup]whitelist_externals}
+allowlist_externals = {[test-setup]allowlist_externals}
 deps =
 commands = {[test-setup]commands}
 
 [testenv:setup36]
 recreate = True
 basepython = python3.6
-whitelist_externals = {[test-setup]whitelist_externals}
+allowlist_externals = {[test-setup]allowlist_externals}
 deps =
 commands = {[test-setup]commands}
 
 [testenv:setup35]
 recreate = True
 basepython = python3.5
-whitelist_externals = {[test-setup]whitelist_externals}
+allowlist_externals = {[test-setup]allowlist_externals}
 deps =
 commands = {[test-setup]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39}, py{35,36,37,38,39}-setup, pypy3, pep8
+envlist = py{35,36,37,38,39}{,-setup}, pypy3, pep8
 skipsdist = True
 
 [pytest]

--- a/tox.sh
+++ b/tox.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # homebrew is installed and so is a brewed openssl
-if [[ $(uname) == "Darwin" ]] && command -v brew &>/dev/null && brew list openssl &>/dev/null; then
+if [[ $(uname) == "Darwin" ]] && command -v brew &>/dev/null && brew list openssl@1.1 &>/dev/null; then
     export ARCHFLAGS="-arch x86_64"
-    export LDFLAGS="-L/usr/local/opt/openssl/lib"
-    export CFLAGS="-I/usr/local/opt/openssl/include"
+    export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+    export CFLAGS="-I/usr/local/opt/openssl@1.1/include"
 fi
 
 exec tox $*


### PR DESCRIPTION
This PR moves us from Travis CI to GitHub Actions as our primary CI due to changes Travis has made to its open source support. We'll still have Travis run tests for now, but will primarily pay attention to GitHub.