### PR TITLE
Feature:: Support for keys without usage flags

### DIFF
--- a/docs/source/examples/actions.rst
+++ b/docs/source/examples/actions.rst
@@ -120,3 +120,24 @@ someone else's public key. That can be done like so::
     # that same passphrase
     dec_message = enc_message.decrypt("S00per_Sekr3t")
 
+
+Ignoring Usage Flags
+^^^^^^^^^^^^^^^^^^^^
+
+.. warning:: Don't do this unless you're *really* sure you need to!
+
+Sometimes a key is created without the correct usage flags and an error is raised when you try to use the key::
+
+    >>> from pgpy import PGPKey, PGPMessage
+    >>> key, _ = PGPKey.from_file('path/to/key_without_usage_flags.asc')
+    >>> message = PGPMessage.new('secret message')
+    >>> encrypted_phrase = key.encrypt(message)
+    PGPError: Key 0123456789ABCDEF does not have the required usage flag EncryptStorage, EncryptCommunications
+
+To disable this check, set ``_require_usage_flags`` to ``False`` on the key before calling the problem function::
+
+    >>> from pgpy import PGPKey, PGPMessage
+    >>> key, _ = PGPKey.from_file('path/to/key_without_usage_flags.asc')
+    >>> key._require_usage_flags = False
+    >>> message = PGPMessage.new('secret message')
+    >>> encrypted_phrase = key.encrypt(message)

--- a/docs/source/examples/keys.rst
+++ b/docs/source/examples/keys.rst
@@ -78,6 +78,28 @@ Keys can be loaded individually into PGPKey objects::
     # or from a text or binary string/bytes/bytearray that has already been read in:
     key, _ = pgpy.PGPKey.from_blob(keyblob)
 
+
+Loading Keys Without Usage Flags
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In some cases the key does not specific with usage flags, an error as the following is raised when the key is not available for some function::
+
+    import pgpy
+    publickey = pgpy.PGPKey.from_blob(bytearray(open('path/to/key_without_usage_flags.asc').read(), 'utf-8'))[0]
+
+    publickey.encrypt('secret message', user=publickey.userids[0].email)
+    >>> PGPError: Key 64C4D5362A88CF19 does not have the required usage flag EncryptStorage, EncryptCommunications
+
+To unapply this flags check, only need assign _require_usage_flags as False to the key before call encrypt function::
+
+    from pgpy import PGPKey
+    from pgpy import PGPMessage
+
+    key, _ = PGPKey.from_file('path/to/key_without_usage_flags.asc')
+    msg_pgp = PGPMessage.new(msg_to_encrypt)
+    key._require_usage_flags = False  # This allow ignore the validation
+    encrypted_phrase = key.encrypt(msg_pgp)
+
 Loading Keys Into a Keyring
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/examples/keys.rst
+++ b/docs/source/examples/keys.rst
@@ -78,28 +78,6 @@ Keys can be loaded individually into PGPKey objects::
     # or from a text or binary string/bytes/bytearray that has already been read in:
     key, _ = pgpy.PGPKey.from_blob(keyblob)
 
-
-Loading Keys Without Usage Flags
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-In some cases the key does not specific with usage flags, an error as the following is raised when the key is not available for some function::
-
-    import pgpy
-    publickey = pgpy.PGPKey.from_blob(bytearray(open('path/to/key_without_usage_flags.asc').read(), 'utf-8'))[0]
-
-    publickey.encrypt('secret message', user=publickey.userids[0].email)
-    >>> PGPError: Key 64C4D5362A88CF19 does not have the required usage flag EncryptStorage, EncryptCommunications
-
-To unapply this flags check, only need assign _require_usage_flags as False to the key before call encrypt function::
-
-    from pgpy import PGPKey
-    from pgpy import PGPMessage
-
-    key, _ = PGPKey.from_file('path/to/key_without_usage_flags.asc')
-    msg_pgp = PGPMessage.new(msg_to_encrypt)
-    key._require_usage_flags = False  # This allow ignore the validation
-    encrypted_phrase = key.encrypt(msg_pgp)
-
 Loading Keys Into a Keyring
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pgpy/decorators.py
+++ b/pgpy/decorators.py
@@ -93,7 +93,11 @@ class KeyAction(object):
                     break
 
             else:  # pragma: no cover
-                raise PGPError("Key {keyid:s} does not have the required usage flag {flags:s}".format(**em))
+                warning = "Key {keyid:s} does not have the required usage flag {flags:s}".format(**em)
+                if key._require_usage_flags:
+                    raise PGPError(warning)
+                else:
+                    logging.warning(warning)
 
         else:
             _key = key

--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1618,6 +1618,7 @@ class PGPKey(Armorable, ParentRef, PGPObject):
         self._signatures = SorteDeque()
         self._uids = SorteDeque()
         self._sibling = None
+        self._require_usage_flags = True
 
     def __bytearray__(self):
         _bytes = bytearray()

--- a/tests/test_05_actions.py
+++ b/tests/test_05_actions.py
@@ -31,6 +31,7 @@ from pgpy.constants import PubKeyAlgorithm
 from pgpy.constants import RevocationReason
 from pgpy.constants import SignatureType
 from pgpy.constants import SymmetricKeyAlgorithm
+from pgpy.errors import PGPError
 from pgpy.packet import Packet
 from pgpy.packet.packets import PrivKeyV4
 from pgpy.packet.packets import PrivSubKeyV4
@@ -978,3 +979,17 @@ class TestPGPKey_Actions(object):
             warnings.simplefilter('ignore')
             dmsg = seckey.decrypt(emsg)
         assert bytes(dmsg.message) == b"This message will have been encrypted"
+
+    def test_ignore_flags(self):
+        # Test that ignoring key flags works properly
+        pubkey, _ = PGPKey.from_file('tests/testdata/keys/targette.pub.rsa.asc')
+        msg = PGPMessage.new('secret message')
+
+        with pytest.raises(PGPError):
+            pubkey.encrypt(msg)
+
+        pubkey._require_usage_flags = False
+        try:
+            pubkey.encrypt(msg)
+        except PGPError as e:
+            pytest.fail("Unexpected exception raised: {}".format(e))


### PR DESCRIPTION
This works for this issue: [Option to override/ignore flags (like gpg)](https://github.com/SecurityInnovation/PGPy/issues/257)

You only need assign _require_usage_flags as False to you key before call encrypt function

```python
from pgpy import PGPKey
from pgpy import PGPMessage

key, _ = PGPKey.from_file('path/to/key_without_usage_flags.asc')
msg_pgp = PGPMessage.new(msg_to_encrypt)
key._require_usage_flags = False  # This allow ignore the validation
encrypted_phrase = key.encrypt(msg_pgp)
```