### PR TITLE
remove unneeded setup_requires which are already in pyproject.toml

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,6 @@ install_requires =
     cryptography>=2.6
     pyasn1
     six>=1.9.0
-setup_requires =
-    setuptools
-    wheel
 python_requires = >=3.5
 
 # doc_requires =


### PR DESCRIPTION
A setup.cfg project metadata section is only ever parsed by setuptools, and thusly does not need to specify that it depends on having setuptools installed (it is already specified in the pyproject.toml)

Wheel is not required either, since it is only actually used by the pyproject.toml specified build backend, and wheel is already specified in the pyproject.toml

pyproject.toml build-requires is intended to specify the basic requirements for acquiring a usable instance of the build backend. These packages are dependencies of PEP 517.

setup_requires is intended only for additional project-specific packages needed in addition to the build backend. These packages are dependenciesof setuptools.setup()

Example difference: wheel is required in order to create a wheel, pyproject.toml specifies the creation of a wheel. wheel is NOT required (and is not used at all) in order to run `python setup.py install`, which does not read pyproject.toml at all.