### PR TITLE
Workarounds for decrypting Research in Motion messages

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1064,6 +1064,10 @@ class PGPMessage(Armorable, PGPObject):
             self._sessionkeys += other._sessionkeys
             self._signatures += other._signatures
             return self
+        
+        if isinstance(other, Opaque):
+            # XXX: fix some other time for 'real'
+            return self  # basically ignore packet for now
 
         raise NotImplementedError(str(type(other)))
 
@@ -2553,7 +2557,7 @@ class PGPKey(Armorable, ParentRef, PGPObject):
 
                 # and file away pgpobj
                 if isinstance(pgpobj, PGPKey):
-                    if pgpobj.is_primary:
+                    if pgpobj.is_primary or not keys:  # avoid erroring the else below if next(reversed(keys)) isn't available yet
                         keys[(pgpobj.fingerprint.keyid, pgpobj.is_public)] = pgpobj
 
                     else:

--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1068,6 +1068,14 @@ class PGPMessage(Armorable, PGPObject):
         if isinstance(other, Opaque):
             # XXX: fix some other time for 'real'
             return self  # basically ignore packet for now
+        
+        if isinstance(other, SKEData):
+            # XXX: fix some other time for 'real'
+            return self  # basically ignore packet for now
+
+        if isinstance(other, pgpy.packet.packets.Trust):
+            # XXX: fix some other time for 'real'
+            return self  # basically ignore packet for now
 
         raise NotImplementedError(str(type(other)))
 


### PR DESCRIPTION
While writing a script to decrypt a number of older encrypted emails encrypted using Research in Motion 1.0 PGP software, I ran into a number of issues. 

The main one is that I ran into a bunch of unsupported packets, including Opaque, SKEData and Trust. I added code to ignore them and ended up with the expected plaintext. I'm not sure what a proper solution would look like.

To other issue I ran into is that some the key files that I have seem to start with a non-primary key. The key parsing code tries to append it to the last key doing `keys[next(reversed(keys))] |= pgpobj`, but since `keys` is empty this fails with an uncaught StopIteration. I worked around it by just treating it as a primary key if `keys` is empty. I'm not sure what one is *supposed* to do in this case though.

I'm not suggesting this PR is merged as-is, I'm putting this forward to document and report these issues, and offering a workaround that worked for my particular use case.



