### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cryptography>=2.6
+cryptography>=3.3
 pyasn1
 six>=1.9.0


### PR DESCRIPTION
Cryptography 2.6 has  vulnerability issues, so upgrading the verision to v3.3

cryptography (v2.6)
CWE-120: Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
CWE-190: Integer Overflow or Wraparound CWE-787: Out-of-bounds Write
CWE-20: Improper Input Validation