### PR TITLE
Cryptography version update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cryptography>=2.6
+cryptography>=3.3.2
 pyasn1
 six>=1.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ packages =
     pgpy.packet
     pgpy.packet.subpackets
 install_requires = 
-    cryptography>=2.6
+    cryptography>=3.3.2
     pyasn1
     six>=1.9.0
 python_requires = >=3.5

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ max-line-length = 160
 [testenv]
 passenv = HOME ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH PATH
 deps =
-    cryptography>=2.6
+    cryptography>=3.3.2
     gpg==1.10.0
     pyasn1
     six>=1.9.0


### PR DESCRIPTION
Upgrading the cryptography version to 3.3.2 & greater because of the code vulnerabilities found  till version v3.3.1

