### PR TITLE
sphinx: use add_css_file() instead of add_stylesheet()

### DIFF
--- a/docs/source/_ext/progress.py
+++ b/docs/source/_ext/progress.py
@@ -144,6 +144,6 @@ def depart_progress(self, node):
 
 
 def setup(app):
-    app.add_stylesheet('progress.css')
+    app.add_css_file('progress.css')
     app.add_node(progress, html=(visit_progress, depart_progress))
     app.add_directive('progress', ProgressTable)


### PR DESCRIPTION
Without this, with Sphinx v4.2.0 there is a failure (see
https://bugs.debian.org/997381), and with Sphinx v4.3.2 there is a
deprecation warning:

> sphinx-build -b html -d build/doctrees   source build/html
> Running Sphinx v4.3.2
> WARNING: while setting up extension _ext.progress: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.