### PR TITLE
Accept passphrases as bytes

### DIFF
--- a/pgpy/packet/fields.py
+++ b/pgpy/packet/fields.py
@@ -1023,8 +1023,10 @@ class String2Key(Field):
 
         # Simple S2K - always done
         hsalt = b''
-        ##TODO: we could accept a passphrase that is optionally already `bytes`
-        hpass = passphrase.encode('utf-8')
+        if isinstance(passphrase, bytes):
+            hpass = passphrase
+        else:
+            hpass = passphrase.encode('utf-8')
 
         # salted, iterated S2K
         if self.specifier >= String2KeyType.Salted:


### PR DESCRIPTION
The OpenPGP specifications are ambiguous about the encoding of
passwords.

In practice, we expect most passphrases to be UTF-8-encoded, but if
the incoming passphrase is in fact a bytestring, we ought to be able
to handle it correctly.

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>

The function signature for `PGPMessage.decrypt()` suggests that `passphrase` can be either `str` or `bytes`, but it chokes when passed a `bytes` object with a backtrace like so:

```
  File "/usr/lib/python3/dist-packages/pgpy/pgp.py", line 1241, in decrypt
    symalg, key = skesk.decrypt_sk(passphrase)
  File "/usr/lib/python3/dist-packages/pgpy/packet/packets.py", line 586, in decrypt_sk
    sk = self.s2k.derive_key(passphrase)
  File "/usr/lib/python3/dist-packages/pgpy/packet/fields.py", line 1027, in derive_key
    hpass = passphrase.encode('utf-8')
AttributeError: 'bytes' object has no attribute 'encode'
```

If it's going to take a while to release 0.6.x, this should probably be applied to the 5.x branch as well, as it's effectively a bugfix to bring the code in line with the documentation.