### PR TITLE
Allow tabs in regex for ASCII validity check

### DIFF
--- a/pgpy/types.py
+++ b/pgpy/types.py
@@ -84,10 +84,10 @@ class Armorable(six.with_metaclass(abc.ABCMeta)):
     @staticmethod
     def is_ascii(text):
         if isinstance(text, six.string_types):
-            return bool(re.match(r'^[ -~\r\n]*$', text, flags=re.ASCII))
+            return bool(re.match(r'^[ -~\r\n\t]*$', text, flags=re.ASCII))
 
         if isinstance(text, (bytes, bytearray)):
-            return bool(re.match(br'^[ -~\r\n]*$', text, flags=re.ASCII))
+            return bool(re.match(br'^[ -~\r\n\t]*$', text, flags=re.ASCII))
 
         raise TypeError("Expected: ASCII input of type str, bytes, or bytearray")  # pragma: no cover
 


### PR DESCRIPTION
They can occur e.g. in armor headers.

Fixes: #395