### PR TITLE
Fix typos

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -184,7 +184,7 @@ Bugs Fixed
 
 New Features
 ------------
- * Standalone sigantures can now be generated
+ * Standalone signatures can now be generated
  * Can now specify which User ID to use when signing things (#121)
  * Can now create new User IDs and User Attributes (#118)
  * Can now add new User IDs and User Attributes to keys (#119)
@@ -197,7 +197,7 @@ New Features
  * Message signatures can now be verified (#117)
  * Messages can now be encrypted/decrypted using a passphrase (#113)
  * Cleartext messages can now be created and signed (#26)
- * Cleartext messages with inline sigantures can now be verified (#27)
+ * Cleartext messages with inline signatures can now be verified (#27)
  * Messages can now be loaded (#102)
  * Messages can now be compressed (#100)
 
@@ -233,7 +233,7 @@ Bugs Fixed
 
 New Features
 ------------
- * Switched the main parse loop to use a bytearray instead of slicing a bytes, resulting in a ~160x speedup in parsing large blocks of pasing. (#87)
+ * Switched the main parse loop to use a bytearray instead of slicing a bytes, resulting in a ~160x speedup in parsing large blocks of passing. (#87)
 
 v0.2.1
 ======

--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -11,7 +11,7 @@ PGPy is focused on eventually reaching complete OpenPGP implementation, adhering
     :text: PGPy is currently focused on achieving :rfc:`4880` compliance for OpenPGP, which is the latest complete OpenPGP Message Format specification. It supersedes RFC 1991 and RFC 2440.
 
     :Versioned Packets, v1:
-        - Tag 18, True,  Symetrically Encrypted and Integrity Protected Data Packet
+        - Tag 18, True,  Symmetrically Encrypted and Integrity Protected Data Packet
 
     :Versioned Packets, v3:
         - Tag 1,  True,  Public-Key Encrypted Session Key Packets
@@ -32,7 +32,7 @@ PGPy is focused on eventually reaching complete OpenPGP implementation, adhering
 
     :Unversioned Packets:
         - Tag 8,  True, Compressed Data Packet
-        - Tag 9,  True, Symetrically Encrypted Data Packet
+        - Tag 9,  True, Symmetrically Encrypted Data Packet
         - Tag 10, True, Marker Packet
         - Tag 11, True, Literal Data Packet
         - Tag 12, True, Trust Packet

--- a/tests/test_05_actions.py
+++ b/tests/test_05_actions.py
@@ -670,7 +670,7 @@ class TestPGPKey_Actions(object):
             return ret
 
         except gpg.errors.GPGMEError:
-            # if we got here, it's because gpg is screwing with us. The tests seem to pass everywhere except in the buildd.
+            # if we got here, it's because gpg is screwing with us. The tests seem to pass everywhere except in the build.
             # Until I can find a better fix, here's another bypass
             return privkey.decrypt(message).message.encode('utf-8')
 

--- a/tests/test_99_regressions.py
+++ b/tests/test_99_regressions.py
@@ -125,7 +125,7 @@ def test_reg_bug_56():
           "=lqIH\n" \
           "-----END PGP PUBLIC KEY BLOCK-----\n"
 
-    # load the keypair above
+    # load the key pair above
     sk = PGPKey()
     sk.parse(sec)
     pk = PGPKey()


### PR DESCRIPTION
Found via `codespell -L nd,wth,te,useg,bu,fpr,fo,clen,varius,unce`