### PR TITLE
fix testsuite regression that immediately crashed without integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ import sys
 from cryptography.hazmat.backends import openssl
 
 openssl_ver = openssl.backend.openssl_version_text().split(' ')[1]
-gpg_ver = 'unknown'
 gnupghome = os.path.join(os.path.dirname(__file__), 'gnupghome')
 
 # ensure external commands we need to run exist
@@ -57,6 +56,7 @@ def pytest_configure(config):
             assert len(list(c.keylist(secret=True))) == 0
 
     else:
+        gpg_ver = 'unknown'
         # we're not running integration tests
         print("running without integration tests")
         # if we're on GitHub CI, this is an error


### PR DESCRIPTION
In commit 08a76fdda9fc2d5e04925a94dec17132ab0a899a, distutils was dropped. Before then, gpg_ver was a global mutable class instance, mutated inside a function and then used. After then, it's a global string that is... also modified inside a function and then used.

Strings cannot be modified inside functions like that. It shadows the variable in the local scope, which means the global variable is inaccessible now. In fact the global variable exists solely to be used inside this function, but now it cannot be.

So, because it can be bound inside the function, it *must* be, but only if python-gpg was installed did this actually occur. If not, we skipped the integration tests and then tried to log the version, assuming that the global default value of "unknown" was still bound, which is no longer true.