### PR TITLE
pin cryptography < 38.0.0 (fix pip install)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,9 @@ packages =
     pgpy
     pgpy.packet
     pgpy.packet.subpackets
-install_requires = 
-    cryptography>=2.6
+# TODO: fix support for cryptography >= 38.0.0 (https://github.com/SecurityInnovation/PGPy/issues/402)
+install_requires =
+    cryptography>=2.6,<38
     pyasn1
     six>=1.9.0
 python_requires = >=3.5


### PR DESCRIPTION
This PR will temporarily address the issue which makes `pip install PGPy` result in a broken environment.

Read more about this issue in:
- https://github.com/SecurityInnovation/PGPy/issues/408
- https://github.com/SecurityInnovation/PGPy/issues/402

----


If any of the following people are still alive (and have write-access to this repo), I would greatly appreciate you merging this PR and triggering a release of PGPy version 0.5.5:

- @J-M0
- @dkg
- @tzaffi 
- @cravgabo 
- @justinkb 
- @sharuzzaman
- @Gee19
- @mgorny
- @vollkorn1982
- @KOLANICH
- @tirkarthi
- @matt-wesley 
- @tydeu 
- @Commod0re
- @jonathancross
- @rot42
- @fuhrysteve
- @iburadempa
- @Wolf480pl

(Sorry for the mass ping, but I have no idea who is dead/alive)