### PR TITLE
Ignore unrecognized signature versions

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -577,9 +577,12 @@ class PGPSignature(Armorable, ParentRef, PGPObject):
 
         # load *one* packet from data
         pkt = Packet(data)
-        if pkt.header.tag == PacketTag.Signature and not isinstance(pkt, Opaque):
-            self._signature = pkt
-
+        if pkt.header.tag == PacketTag.Signature:
+            if isinstance(pkt, Opaque):
+                # this is an unrecognized version.
+                pass
+            else:
+                self._signature = pkt
         else:
             raise ValueError('Expected: Signature. Got: {:s}'.format(pkt.__class__.__name__))
 


### PR DESCRIPTION
As new versions of OpenPGP signatures are defined, implementations may provide multiple signatures, one of an older version for legacy clients and one of a new version for clients that can read the new signature form.

PGPy should skip over any signature whose version is not recognized.  Otherwise, when it encounters one of these multi-sig constructs, it will throw an error even if it could have validated another signature.