### PR TITLE
fix erroneous predicate in PGPKey.verify

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -2478,7 +2478,7 @@ class PGPKey(Armorable, ParentRef, PGPObject):
 
             else:
                 if isinstance(subj, PGPKey):
-                    self_verifying = signerFp == subj.fingerprint
+                    self_verifying = str(sig.signer_fingerprint) == subj.fingerprint
                 else:
                     self_verifying = False
                 


### PR DESCRIPTION
There is no object named "signerFp".  From the variant code in pgpy/pgp1.py (see #419), it appears that signerFp is supposed to be str(sig.signer_fingerprint) so we just write that explicitly here.