### PR TITLE
Try to avoid tox test setup failures in unit-tests and test-setup CI jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,15 @@ ignore = E201,E202,E221,E251,E265,F403,F821,N805,W503
 max-line-length = 160
 
 [testenv]
-passenv = HOME ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH PATH
+passenv =
+    HOME
+    ARCHFLAGS
+    LDFLAGS
+    CFLAGS
+    INCLUDE
+    LIB
+    LD_LIBRARY_PATH
+    PATH
 deps =
     cryptography>=2.6
     gpg==1.10.0


### PR DESCRIPTION
I'm seeing errors like this in the test-setup and unit-tests CI jobs:

> py: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'HOME ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH PATH'

and:

> py39-setup: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'HOME ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH PATH'

Despite the fact that [tox documentation](https://tox.wiki/en/3.1.2/config.html) says that "passenv" is "SPACE-SEPARATED-GLOBNAMES", the setup seems to think that "pass_env" (which is not "passenv", note the lack of underscore) is somehow bad.  Maybe putting each value on its own line will satisfy this check?