### PR TITLE
remove more `six` references

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,11 +9,6 @@ exclude_lines =
     # skip abstract methods
     @(abc\.)?abstract
 
-    # Python 2.x compatibility stuff
-    if six.PY2:
-    if six.PY3:
-    def __nonzero__
-
     # debug-only code
     def __repr__
 

--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,6 @@ Requirements
 
 - `pyasn1 <https://pypi.python.org/pypi/pyasn1/>`_
 
-- `six <https://pypi.python.org/pypi/six>`_
-
 License
 -------
 

--- a/gentoo/pgpy-0.4.0.ebuild
+++ b/gentoo/pgpy-0.4.0.ebuild
@@ -19,7 +19,6 @@ IUSE=""
 DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 RDEPEND="dev-python/singledispatch[${PYTHON_USEDEP}]
          dev-python/pyasn1[${PYTHON_USEDEP}]
-         >=dev-python/six-1.9.0[${PYTHON_USEDEP}]
          >=dev-python/cryptography-1.1.0[${PYTHON_USEDEP}]
          $(python_gen_cond_dep 'dev-python/enum34[${PYTHON_USEDEP}]' python2_7 python3_3)"
 DOCS=( README.rst )

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ deps =
     cryptography>=2.6
     gpg==1.10.0
     pyasn1
-    six>=1.9.0
     pytest
     pytest-cov
     # We need a patched version of pytest-order to run on 3.5 and handle parameterized tests


### PR DESCRIPTION
#412 removed the `six` dependency. Remove the other references in the docs and CI.