### PR TITLE
keys made with the RSAEncrypt usage flag should be usable for encrypt…

### DIFF
--- a/pgpy/packet/packets.py
+++ b/pgpy/packet/packets.py
@@ -255,7 +255,7 @@ class PKESessionKeyV3(PKESessionKey):
         m = bytearray(self.int_to_bytes(symalg) + symkey)
         m += self.int_to_bytes(sum(bytearray(symkey)) % 65536, 2)
 
-        if self.pkalg == PubKeyAlgorithm.RSAEncryptOrSign:
+        if self.pkalg == PubKeyAlgorithm.RSAEncryptOrSign or self.pkalg == PubKeyAlgorithm.RSAEncrypt:
             encrypter = pk.keymaterial.__pubkey__().encrypt
             encargs = (bytes(m), padding.PKCS1v15(),)
 


### PR DESCRIPTION
keys made with the RSAEncrypt usage flag should be usable for encryption. keys nowadays are made with the RSAEncryptOrSign but older keys are not.