### PR TITLE
Offer implementation of the Stateless OpenPGP Command-Line Interface ("SOP") 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Requirements
 
 To use `sopgpy` you'll also need:
 
-- `sop <https://pypi.org/project/sop/>`_
+- `sop <https://pypi.org/project/sop/>`_ >= 0.5.1
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,11 @@ To install PGPy, simply:
 
     $ pip install PGPy
 
+Command-Line Interface
+----------------------
+
+This module will install `sopgpy`, an implementation of the `Stateless OpenPGP Command-line Interface <https://datatracker.ietf.org/doc/draft-dkg-openpgp-stateless-cli/>`_.
+
 Documentation
 -------------
 
@@ -59,6 +64,10 @@ Requirements
 - `pyasn1 <https://pypi.python.org/pypi/pyasn1/>`_
 
 - `six <https://pypi.python.org/pypi/six>`_
+
+To use `sopgpy` you'll also need:
+
+- `sop <https://pypi.org/project/sop/>`_
 
 License
 -------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,18 @@
 Changelog
 *********
 
+v0.7.0
+======
+
+(not yet released)
+
+API additions
+-------------
+
+PGPSignatures represents a detached signature, which can contain more
+than a single signature.  It is a simple sequence of individual
+PGPSignature objects.
+
 v0.6.0
 ======
 

--- a/pgpy/__init__.py
+++ b/pgpy/__init__.py
@@ -5,6 +5,7 @@ from .pgp import PGPKey
 from .pgp import PGPKeyring
 from .pgp import PGPMessage
 from .pgp import PGPSignature
+from .pgp import PGPSignatures
 from .pgp import PGPUID
 
 __all__ = ['constants',
@@ -13,4 +14,5 @@ __all__ = ['constants',
            'PGPKeyring',
            'PGPMessage',
            'PGPSignature',
+           'PGPSignatures',
            'PGPUID', ]

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -34,8 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import io
 import os
-import sop
-import pgpy #type: ignore
 import codecs
 import logging
 import packaging.version
@@ -45,7 +43,8 @@ from datetime import datetime, timezone
 from typing import List, Union, Optional, Set, Tuple, MutableMapping, Dict, Callable
 from argparse import Namespace, _SubParsersAction, ArgumentParser
 
-__version__ = '0.3.0'
+import sop
+import pgpy
 
 # hack to assemble multiple signature packets! reported to PGPy at
 # https://github.com/SecurityInnovation/PGPy/issues/197#issuecomment-1027582415
@@ -69,7 +68,7 @@ class _multisig(pgpy.types.Armorable): #type: ignore
 class SOPGPy(sop.StatelessOpenPGP):
     def __init__(self) -> None:
         self.pgpy_version = packaging.version.Version(metadata.version('pgpy'))
-        super().__init__(name='SOPGPy', version=f'{__version__}',
+        super().__init__(name='SOPGPy', version=f'{self.pgpy_version}',
                          backend=f'PGPy {self.pgpy_version}',
                          description=f'Stateless OpenPGP using PGPy {self.pgpy_version}')
 

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -37,12 +37,15 @@ import logging
 from datetime import datetime
 from typing import List, Union, Optional, Set, Tuple, MutableMapping, Dict
 
+__version__ = '0.1.0'
+
 class SOPGPy(sop.StatelessOpenPGP):
     def __init__(self) -> None:
-        super().__init__(name='SOPGPy', version=pgpy.__version__,
+        super().__init__(name='SOPGPy', version=f'{__version__}/{pgpy.__version__}',
                          description=f'Stateless OpenPGP using PGPy {pgpy.__version__}')
 
-    # implemented ciphers, in the order we prefer them:
+    # implemented ciphers that we are willing to use to encrypt, in
+    # the order we prefer them:
     _cipherprefs:List[pgpy.constants.SymmetricKeyAlgorithm] = \
         [pgpy.constants.SymmetricKeyAlgorithm.AES256,
          pgpy.constants.SymmetricKeyAlgorithm.AES192,
@@ -52,8 +55,7 @@ class SOPGPy(sop.StatelessOpenPGP):
          pgpy.constants.SymmetricKeyAlgorithm.Camellia128,
          pgpy.constants.SymmetricKeyAlgorithm.CAST5,
          pgpy.constants.SymmetricKeyAlgorithm.TripleDES,
-         pgpy.constants.SymmetricKeyAlgorithm.Blowfish,
-         pgpy.constants.SymmetricKeyAlgorithm.IDEA]
+         pgpy.constants.SymmetricKeyAlgorithm.Blowfish]
         
     def _maybe_armor(self, armor:bool, data:Union[pgpy.PGPSignature,pgpy.PGPMessage,pgpy.PGPKey]) -> bytes:
         if (armor):

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
 '''OpenPGP Interoperability Test Suite Generic Functionality using PGPy
 

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -227,8 +227,16 @@ class SOPGPy(sop.StatelessOpenPGP):
                 signers:List[str],
                 recipients:List[str]) -> bytes:
         # FIXME!
-        if literaltype != 'binary' or mode != 'any' or passwords or sessionkey or signers:
-            raise sop.SOPUnsupportedOption('sopgpy does not support any arguments to encrypt yet, sorry')
+        if literaltype != 'binary'
+            raise sop.SOPUnsupportedOption('sopgpy encrypt does not support --as yet')
+        if or mode != 'any':
+            raise sop.SOPUnsupportedOption('sopgpy encrypt does not support --mode yet')
+        if passwords:
+            raise sop.SOPUnsupportedOption('sopgpy encrypt does not support --with-password yet')
+        if signers:
+            raise sop.SOPUnsupportedOption('sopgpy encrypt does not support --sign-with yet')
+        if sessionkey:
+            raise sop.SOPUnsupportedOption('sopgpy encrypt does not support --session-key yet')
         
         certs: List[pgpy.PGPKey] = []
         for fname in recipients:
@@ -273,8 +281,16 @@ class SOPGPy(sop.StatelessOpenPGP):
                 end:Optional[str],
                 secretkeys:List[str]) -> bytes:
         # FIXME!!!
-        if sessionkey or passwords or verifications or signers or start or end:
-            raise sop.SOPUnsupportedOption('sopgpy does not support any arguments to decrypt yet, sorry')
+        if sessionkey:
+            raise sop.SOPUnsupportedOption('sopgpy does not support --session-key yet')
+        if passwords: 
+            raise sop.SOPUnsupportedOption('sopgpy does not support --with-password yet')
+        if verifications:
+            raise sop.SOPUnsupportedOption('sopgpy does not support --verify-out yet')
+        if signers:
+            raise sop.SOPUnsupportedOption('sopgpy does not support --verify-with yet')
+        if start or end:
+            raise sop.SOPUnsupportedOption('sopgpy does not support --verify-not-before or --verify-not-after yet')
         
         seckeys: List[pgpy.PGPKey] = []
         for fname in secretkeys:

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -372,8 +372,8 @@ class SOPGPy(sop.StatelessOpenPGP):
                             break
                         except pgpy.errors.PGPDecryptionError:
                             pass
-            if ret is None:
-                logging.warning(f'could not decrypt with password from {p}{extratext}')
+                if ret is None:
+                    logging.warning(f'could not decrypt with password from {p}{extratext}')
         if ret is None:
             raise sop.SOPCouldNotDecrypt(f'could not find anything capable of decryption')
         return (ret, sigs, None)

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -253,15 +253,15 @@ class SOPGPy(sop.StatelessOpenPGP):
 
     def decrypt(self,
                 data:bytes,
-                sessionkey:Optional[sop.SOPSessionKey],
+                wantsessionkey:bool,
                 passwords:MutableMapping[str,bytes],
                 signers:MutableMapping[str,bytes],
                 start:Optional[datetime],
                 end:Optional[datetime],
-                secretkeys:MutableMapping[str,bytes]) -> Tuple[bytes, List[sop.SOPSigResult]]:
+                secretkeys:MutableMapping[str,bytes]) -> Tuple[bytes, List[sop.SOPSigResult], Optional[sop.SOPSessionKey]]:
         # FIXME!!!
-        if sessionkey:
-            raise sop.SOPUnsupportedOption('sopgpy does not support --session-key yet')
+        if wantsessionkey:
+            raise sop.SOPUnsupportedOption('sopgpy does not support --session-key-out yet')
         if passwords: 
             raise sop.SOPUnsupportedOption('sopgpy does not support --with-password yet')
         if signers:
@@ -289,7 +289,7 @@ class SOPGPy(sop.StatelessOpenPGP):
                 logging.warning(f'could not decrypt with {seckey.fingerprint}')
         if ret is None:
             raise sop.SOPCouldNotDecrypt(f'could not find anything capable of decryption')
-        return (ret, [])
+        return (ret, [], None)
 
     def armor(self, data:bytes, label:Optional[sop.SOPArmorLabel]) -> bytes:
         obj:Union[None,pgpy.PGPMessage,pgpy.PGPKey,pgpy.PGPSignature] = None

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -366,7 +366,7 @@ class SOPGPy(sop.StatelessOpenPGP):
                     # see https://docs.python.org/3/library/datetime.html#aware-and-naive-objects
                     if sigtime.tzinfo is None:
                         sigtime = sigtime.replace(tzinfo=timezone.utc)
-                    if goodsig.verified:
+                    if ('issues' in goodsig._fields and goodsig.issues == 0) or ('verified' in goodsig._fields and goodsig.verified):
                         if start is None or sigtime >= start:
                             if end is None or sigtime <= end:
                                 sigs += [sop.SOPSigResult(goodsig.signature.created, goodsig.by.fingerprint, cert.fingerprint, goodsig.signature.__repr__())]

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -1,0 +1,308 @@
+#!/usr/bin/python3
+'''OpenPGP Interoperability Test Suite Generic Functionality using PGPy
+
+Author: Daniel Kahn Gillmor
+Date: 2019-10-24
+License: MIT (see below)
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+'''
+
+import io
+import os
+import sop
+import pgpy
+import logging
+
+from typing import List, Union, Optional, Set
+
+class SOPGPy(sop.StatelessOpenPGP):
+    def __init__(self):
+        super().__init__(prog='SOPGPy', version=pgpy.__version__,
+                         description=f'Stateless OpenPGP using PGPy {pgpy.__version__}')
+
+    # implemented ciphers, in the order we prefer them:
+    _cipherprefs = [pgpy.constants.SymmetricKeyAlgorithm.AES256,
+                    pgpy.constants.SymmetricKeyAlgorithm.AES192,
+                    pgpy.constants.SymmetricKeyAlgorithm.AES128,
+                    pgpy.constants.SymmetricKeyAlgorithm.Camellia256,
+                    pgpy.constants.SymmetricKeyAlgorithm.Camellia192,
+                    pgpy.constants.SymmetricKeyAlgorithm.Camellia128,
+                    pgpy.constants.SymmetricKeyAlgorithm.CAST5,
+                    pgpy.constants.SymmetricKeyAlgorithm.TripleDES,
+                    pgpy.constants.SymmetricKeyAlgorithm.Blowfish,
+                    pgpy.constants.SymmetricKeyAlgorithm.IDEA]
+
+        
+    def _maybe_armor(self, armor:bool, data:Union[pgpy.PGPSignature,pgpy.PGPMessage,pgpy.PGPKey]):
+        if (armor):
+            return str(data).encode('ascii')
+        else:
+            return bytes(data)
+
+    def _get_pgp_signature(self, fname:str) -> pgpy.PGPSignature:
+        sig:Optional[pgpy.PGPSignature] = None
+        if fname.startswith('@FD:'):
+            fd = int(fname.split(':', maxsplit=1)[1])
+            with open(fd, 'rb') as filed:
+                data:bytes = filed.read()
+                sig = pgpy.PGPSignature.from_blob(data)
+        elif fname.startswith('@ENV:'):
+            sig = pgpy.PGPSignature.from_blob(os.environ[fname.split(':', maxsplit=1)[1]])
+        else:
+            sig = pgpy.PGPSignature.from_file(fname)
+        return sig
+        
+    def _get_pgp_key(self, fname:str, secret:bool) -> pgpy.PGPKey:
+        # handle @FD: and @ENV: here
+        key:Optional[pgpy.PGPKey] = None
+        if fname.startswith('@FD:'):
+            fd = int(fname.split(':', maxsplit=1)[1])
+            with open(fd, 'rb') as filed:
+                data:bytes = filed.read()
+                key, _ = pgpy.PGPKey.from_blob(data)
+        elif fname.startswith('@ENV:'):
+            key, _ = pgpy.PGPKey.from_blob(os.environ[fname.split(':', maxsplit=1)[1]])
+        else:
+            key, _ = pgpy.PGPKey.from_file(fname)
+        if secret:
+            if key.is_public:
+                raise Exception(f'file "{fname}" does not contain OpenPGP secret key material (probably a certificate)')
+            logging.info(f'loaded secret key {key.fingerprint} from {fname}')
+
+        if not secret:
+            if not key.is_public:
+                raise Exception(f'file "{fname}" does not contain an OpenPGP certificate (probably a secret key)')
+            logging.info(f'loaded certificate {key.fingerprint} from {fname}')
+        return key
+        
+    def generate(self,
+                 inp:io.BufferedReader,
+                 armor:bool,
+                 uids:List[str]) -> bytes:
+        primary = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.EdDSA,
+                                  pgpy.constants.EllipticCurveOID.Ed25519)
+        primaryflags: Set[int] = set()
+        primaryflags.add(pgpy.constants.KeyFlags.Certify)
+        primaryflags.add(pgpy.constants.KeyFlags.Sign)
+        first: bool = True
+        uidoptions = {
+            'usage': primaryflags,
+            'primary': True,
+            'hashes': [pgpy.constants.HashAlgorithm.SHA512,
+                       pgpy.constants.HashAlgorithm.SHA384,
+                       pgpy.constants.HashAlgorithm.SHA256,
+                       pgpy.constants.HashAlgorithm.SHA224],
+            'ciphers': [pgpy.constants.SymmetricKeyAlgorithm.AES256,
+                        pgpy.constants.SymmetricKeyAlgorithm.AES192,
+                        pgpy.constants.SymmetricKeyAlgorithm.AES128],
+            'compression': [pgpy.constants.CompressionAlgorithm.Uncompressed],
+            'keyserver_flags': [pgpy.constants.KeyServerPreferences.NoModify]
+        }
+
+        for uid in uids:
+            primary.add_uid(pgpy.PGPUID.new(uid), **uidoptions)
+            if 'primary' in uidoptions: # only first User ID is Primary
+                del uidoptions['primary']
+
+        subkey = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.ECDH,
+                                 pgpy.constants.EllipticCurveOID.Curve25519)
+        subflags = pgpy.constants.KeyFlags.EncryptCommunications
+        subflags |= pgpy.constants.KeyFlags.EncryptStorage
+        primary.add_subkey(subkey, usage=subflags)
+        return self._maybe_armor(armor, primary)
+
+
+    def convert(self,
+                inp:io.BufferedReader,
+                armor:bool) -> bytes:
+        data: bytes = inp.read()
+        seckey, _ = pgpy.PGPKey.from_blob(data)
+        return self._maybe_armor(armor, seckey.pubkey)
+
+
+    def sign(self,
+             inp:io.BufferedReader,
+             armor:bool,
+             sigtype:str,
+             signers:List[str]) -> bytes:
+        if not signers:
+            raise Exception("Need at least one OpenPGP Secret Key file as an argument")
+
+        seckeys = []
+        for keyfile in signers:
+            seckey = self._get_pgp_key(keyfile, True)
+            seckeys.append(seckey)
+
+        data:bytes = inp.read()
+        msg:Optional[pgpy.PGPMessage] = None
+        if sigtype == 'text':
+            msg = pgpy.PGPMessage.new(data.decode('utf8'), cleartext=True, format='u')
+        elif sigtype == 'binary':
+            msg = pgpy.PGPMessage.new(data, format='b')
+        else:
+            raise Exception(f'unknown signature type {sigtype}')
+        signatures:List[pgpy.PGPSignature] = []
+        for seckey in seckeys:
+            signatures.append(seckey.sign(msg))
+
+        # hack to assemble multiple signature packets! FIXME: need to report to PGPy
+        sigdata:bytes = b''
+        for signature in signatures:
+            sigdata += bytes(seckey.sign(msg))
+        class _multisig(pgpy.types.Armorable):
+            @property
+            def magic(self):
+                return 'SIGNATURE'
+            def parse(self, x):
+                self._bytes = x
+            def __bytes__(self):
+                return self._bytes
+        return self._maybe_armor(armor, _multisig.from_blob(sigdata))
+
+
+    def verify(self,
+               inp:io.BufferedReader,
+               start:Optional[str],
+               end:Optional[str],
+               sig:str,
+               signers:List[str]) -> bytes:
+        signature = self._get_pgp_signature(sig)
+        certs: List[pgpy.PGPKey] = []
+        for fname in signers:
+            cert = self._get_pgp_key(fname, False)
+            certs.append(cert)
+
+        if not certs:
+            raise Exception('needs at least one OpenPGP certificate')
+
+        if start is not None or end is not None:
+            raise Exception('have not implemented --not-before and --not-after')
+        
+        data:bytes = inp.read()
+        good:bool = False
+        ret:bytes = b''
+        for cert in certs:
+            try:
+                verif = cert.verify(data, signature=signature)
+                for sig in verif.good_signatures:
+                    if sig.verified:
+                        ts = sig.signature.created.strftime('%Y-%m-%dT%H:%M:%SZ\n')
+                        good = True
+                        ret += ts.encode('ascii')
+            except:
+                pass
+        if not good:
+            raise Exception("No good signature found")
+        return ret
+
+
+    def encrypt(self,
+                inp:io.BufferedReader,
+                literaltype:str,
+                armor:bool,
+                mode:str,
+                passwords:List[str],
+                sessionkey:Optional[str],
+                signers:List[str],
+                recipients:List[str]) -> bytes:
+        # FIXME!
+        if literaltype != 'binary' or mode != 'any' or passwords or sessionkey or signers:
+            raise Exception('sopgpy does not support any arguments to encrypt yet, sorry')
+        
+        certs: List[pgpy.PGPKey] = []
+        for fname in recipients:
+            cert = self._get_pgp_key(fname, False)
+            certs.append(cert)
+
+        if not certs:
+            raise Exception('needs at least one OpenPGP certificate')
+
+        ciphers = set(self._cipherprefs)
+        for cert in certs:
+            keyciphers=set()
+            for uid in cert.userids:
+                if uid.selfsig and uid.selfsig.cipherprefs:
+                    for cipher in uid.selfsig.cipherprefs:
+                        keyciphers.add(cipher)
+            ciphers = ciphers.intersection(keyciphers)
+        cipher = None
+        for c in self._cipherprefs:
+            if c in ciphers:
+                cipher = c
+                break
+        # AES128 is MTI in RFC4880:
+        if cipher is None:
+            cipher = pgpy.constants.SymmetricKeyAlgorithm.AES128
+        data: bytes = inp.read()
+        sessionkey = cipher.gen_key()
+        msg = pgpy.PGPMessage.new(data, compression=pgpy.constants.CompressionAlgorithm.Uncompressed)
+        for cert in certs:
+            msg = cert.encrypt(msg, cipher=cipher, sessionkey=sessionkey)
+        del sessionkey
+        return self._maybe_armor(armor, msg)
+
+
+    def decrypt(self,
+                inp:io.BufferedReader,
+                sessionkey:Optional[str],
+                passwords:List[str],
+                verifications:Optional[str],
+                signers:List[str],
+                start:Optional[str],
+                end:Optional[str],
+                secretkeys:List[str]) -> bytes:
+        # FIXME!!!
+        if sessionkey or passwords or verifications or signers or start or end:
+            raise Exception('sopgpy does not support any arguments to decrypt yet, sorry')
+        
+        seckeys: List[pgpy.PGPKey] = []
+        for fname in secretkeys:
+            seckey = self._get_pgp_key(fname, True)
+            seckeys.append(seckey)
+
+        if not seckeys:
+            raise Exception('needs at least one OpenPGP secret key')
+        data: bytes = inp.read()
+        encmsg:pgpy.PGPMessage = pgpy.PGPMessage.from_blob(data)
+        ret:Optional[bytes] = None
+        for seckey in seckeys:
+            try:
+                msg: pgpy.PGPMessage = seckey.decrypt(encmsg)
+                out:Union[str,bytes] = msg.message
+                if isinstance(out, str):
+                    ret = out.encode('utf8')
+                else:
+                    ret = out
+                break
+            except pgpy.errors.PGPDecryptionError as e:
+                logging.warning(f'could not decrypt with {seckey.fingerprint}')
+        if ret is None:
+            raise Exception(f'could not find anything capable of decryption')
+        return ret
+
+    
+def main():
+    sop = SOPGPy()
+    sop.dispatch()
+
+if __name__ == '__main__':
+    main()

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -40,7 +40,7 @@ from datetime import datetime, timezone
 from typing import List, Union, Optional, Set, Tuple, MutableMapping, Dict, Callable
 from argparse import Namespace, _SubParsersAction, ArgumentParser
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 # hack to assemble multiple signature packets! reported to PGPy at
 # https://github.com/SecurityInnovation/PGPy/issues/197#issuecomment-1027582415
@@ -141,7 +141,7 @@ class SOPGPy(sop.StatelessOpenPGP):
 
 
     def generate_key(self, armor:bool=True, uids:List[str]=[],
-                     keypassword:Optional[str]=None,
+                     keypassword:Optional[bytes]=None,
                      **kwargs:Namespace) -> bytes:
         self.raise_on_unknown_options(**kwargs)
         primary = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.EdDSA,

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -182,7 +182,7 @@ class SOPGPy(sop.StatelessOpenPGP):
                 goodsig:pgpy.types.sigsubj
                 for goodsig in verif.good_signatures:
                     if goodsig.verified:
-                        ret += [sop.SOPSigResult(goodsig.signature.created, cert.fingerprint, cert)]
+                        ret += [sop.SOPSigResult(goodsig.signature.created, cert.fingerprint, goodsig.signature.__repr__())]
             except:
                 pass
         if not ret:

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -79,8 +79,8 @@ class SOPGPy(sop.StatelessOpenPGP):
          pgpy.constants.SymmetricKeyAlgorithm.CAST5,
          pgpy.constants.SymmetricKeyAlgorithm.TripleDES,
          pgpy.constants.SymmetricKeyAlgorithm.Blowfish]
-        
-    def _maybe_armor(self, armor:bool, data:Union[pgpy.PGPSignature,pgpy.PGPMessage,pgpy.PGPKey]) -> bytes:
+
+    def _maybe_armor(self, armor:bool, data:pgpy.types.Armorable) -> bytes:
         if (armor):
             return str(data).encode('ascii')
         else:

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -228,7 +228,7 @@ class SOPGPy(sop.StatelessOpenPGP):
                 recipients:List[str]) -> bytes:
         # FIXME!
         if literaltype != 'binary' or mode != 'any' or passwords or sessionkey or signers:
-            raise Exception('sopgpy does not support any arguments to encrypt yet, sorry')
+            raise sop.SOPUnsupportedOption('sopgpy does not support any arguments to encrypt yet, sorry')
         
         certs: List[pgpy.PGPKey] = []
         for fname in recipients:
@@ -274,7 +274,7 @@ class SOPGPy(sop.StatelessOpenPGP):
                 secretkeys:List[str]) -> bytes:
         # FIXME!!!
         if sessionkey or passwords or verifications or signers or start or end:
-            raise Exception('sopgpy does not support any arguments to decrypt yet, sorry')
+            raise sop.SOPUnsupportedOption('sopgpy does not support any arguments to decrypt yet, sorry')
         
         seckeys: List[pgpy.PGPKey] = []
         for fname in secretkeys:

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -148,7 +148,11 @@ class SOPGPy(sop.StatelessOpenPGP):
         seckeys:MutableMapping[str,pgpy.PGPKey] = self._get_keys(signers)
         msg:pgpy.PGPMessage
         if sigtype is sop.SOPSigType.text:
-            msg = pgpy.PGPMessage.new(data.decode('utf8'), cleartext=True, format='u')
+            try:
+                datastr:str = data.decode(encoding='utf-8')
+            except UnicodeDecodeError:
+                raise sop.SOPNotUTF8Text('Message was not encoded UTF-8 text')
+            msg = pgpy.PGPMessage.new(datastr, cleartext=True, format='u')
         elif sigtype == sop.SOPSigType.binary:
             msg = pgpy.PGPMessage.new(data, format='b')
         else:

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -161,7 +161,8 @@ class SOPGPy(sop.StatelessOpenPGP):
         for handle,seckey in seckeys.items():
             signatures.append(seckey.sign(msg))
 
-        # hack to assemble multiple signature packets! FIXME: need to report to PGPy
+        # hack to assemble multiple signature packets! reported to PGPy at
+        # https://github.com/SecurityInnovation/PGPy/issues/197#issuecomment-1027582415
         sigdata:bytes = b''
         for signature in signatures:
             sigdata += bytes(seckey.sign(msg))

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -40,7 +40,7 @@ from datetime import datetime
 from typing import List, Union, Optional, Set, Tuple, MutableMapping, Dict
 from argparse import Namespace, _SubParsersAction, ArgumentParser
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 class SOPGPy(sop.StatelessOpenPGP):
     def __init__(self) -> None:

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -267,7 +267,7 @@ class SOPGPy(sop.StatelessOpenPGP):
             raise sop.SOPMissingRequiredArgument('needs at least one OpenPGP certificate')
         signature = self._get_pgp_signature(sig)
         certs:MutableMapping[str,pgpy.PGPKey] = self._get_certs(signers)
-        
+
         ret:List[sop.SOPSigResult] = self._check_sigs(certs, data, signature, start, end)
         if not ret:
             raise sop.SOPNoSignature("No good signature found")
@@ -348,7 +348,7 @@ class SOPGPy(sop.StatelessOpenPGP):
             else:
                 sig = key.sign(msg)
             msg |= sig
-        
+
         for handle, cert in certs.items():
             msg = cert.encrypt(msg, cipher=cipher, sessionkey=sessionkey)
         for p, pw in pws.items():
@@ -398,9 +398,9 @@ class SOPGPy(sop.StatelessOpenPGP):
         # FIXME!!!
         if wantsessionkey:
             raise sop.SOPUnsupportedOption('sopgpy does not support --session-key-out yet')
-        if sessionkeys: 
+        if sessionkeys:
             raise sop.SOPUnsupportedOption('sopgpy does not support --with-session-key yet')
-        
+
         if signers:
             certs = self._get_certs(signers)
         if not secretkeys and not passwords and not sessionkeys:
@@ -592,12 +592,12 @@ class SOPGPy(sop.StatelessOpenPGP):
             return str(msg).encode('utf-8')
         else:
             return bytes(msg)
-        
-    def inline_verify(self, data:bytes,
-                      start:Optional[datetime]=None,
-                      end:Optional[datetime]=None,
-                      signers:MutableMapping[str,bytes]={},
-                      **kwargs:Namespace) -> Tuple[bytes, List[sop.SOPSigResult]]:
+
+    def inline_verify(self, data: bytes,
+                      start: Optional[datetime] = None,
+                      end: Optional[datetime] = None,
+                      signers: MutableMapping[str, bytes] = {},
+                      **kwargs: Namespace) -> Tuple[bytes, List[sop.SOPSigResult]]:
         self.raise_on_unknown_options(**kwargs)
         if not signers:
             raise sop.SOPMissingRequiredArgument('needs at least one OpenPGP certificate')

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -33,6 +33,7 @@ import sop
 import pgpy #type: ignore
 import codecs
 import logging
+from importlib import metadata
 
 from datetime import datetime
 from typing import List, Union, Optional, Set, Tuple, MutableMapping, Dict
@@ -42,8 +43,9 @@ __version__ = '0.1.0'
 
 class SOPGPy(sop.StatelessOpenPGP):
     def __init__(self) -> None:
-        super().__init__(name='SOPGPy', version=f'{__version__}/{pgpy.__version__}',
-                         description=f'Stateless OpenPGP using PGPy {pgpy.__version__}')
+        pgpy_version = metadata.version('pgpy')
+        super().__init__(name='SOPGPy', version=f'{__version__}/{pgpy_version}',
+                         description=f'Stateless OpenPGP using PGPy {pgpy_version}')
 
     # implemented ciphers that we are willing to use to encrypt, in
     # the order we prefer them:

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -377,7 +377,7 @@ class SOPGPy(sop.StatelessOpenPGP):
                     if ('issues' in goodsig._fields and goodsig.issues == 0) or ('verified' in goodsig._fields and goodsig.verified):
                         if start is None or sigtime >= start:
                             if end is None or sigtime <= end:
-                                sigs += [sop.SOPSigResult(goodsig.signature.created, goodsig.by.fingerprint, cert.fingerprint, goodsig.signature.__repr__())]
+                                sigs += [sop.SOPSigResult(when=goodsig.signature.created, signing_fpr=goodsig.by.fingerprint, primary_fpr=cert.fingerprint, moreinfo=goodsig.signature.__repr__())]
             except:
                 pass
         return sigs

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -617,5 +617,11 @@ def main() -> None:
     sop = SOPGPy()
     sop.dispatch()
 
+
+def get_parser() -> ArgumentParser:
+    'Return an ArgumentParser object for the sake of tools like argparse-manpage'
+    return SOPGPy()._parser
+
+
 if __name__ == '__main__':
     main()

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -490,12 +490,15 @@ class SOPGPy(sop.StatelessOpenPGP):
             elif label is sop.SOPArmorLabel.auto: # try to guess
                 try:
                     obj, _ = pgpy.PGPKey.from_blob(data)
+                    len(str(obj)) # try to get a string out of the supposed PGPKey, triggering an error if unset
                 except:
                     try:
                         obj = pgpy.PGPSignature.from_blob(data)
+                        len(str(obj)) # try to get a string out of the supposed PGPKey, triggering an error if unset
                     except:
                         try:
                             obj = pgpy.PGPMessage.from_blob(data)
+                            len(str(obj)) # try to get a string out of the supposed PGPKey, triggering an error if unset
                         except:
                             obj = pgpy.PGPMessage.new(data)
             else:

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -173,6 +173,10 @@ class SOPGPy(sop.StatelessOpenPGP):
         subflags.add(pgpy.constants.KeyFlags.EncryptCommunications)
         subflags.add(pgpy.constants.KeyFlags.EncryptStorage)
         primary.add_subkey(subkey, usage=subflags)
+        if keypassword is not None:
+            primary.protect(keypassword,
+                            pgpy.constants.SymmetricKeyAlgorithm.AES256,
+                            pgpy.constants.HashAlgorithm.SHA512)
         return self._maybe_armor(armor, primary)
 
 

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -71,7 +71,7 @@ class SOPGPy(sop.StatelessOpenPGP):
     def __init__(self) -> None:
         self.pgpy_version = packaging.version.Version(metadata.version('pgpy'))
         self.cryptography_version = packaging.version.Version(metadata.version('cryptography'))
-        super().__init__(name='SOPGPy', version=f'{self.pgpy_version}',
+        super().__init__(name='sopgpy', version=f'{self.pgpy_version}',
                          backend=f'PGPy {self.pgpy_version}',
                          extended=f'python-cryptography {self.cryptography_version}\n{openssl.backend.openssl_version_text()}',
                          description=f'Stateless OpenPGP using PGPy {self.pgpy_version}')

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -3,28 +3,33 @@
 '''OpenPGP Interoperability Test Suite Generic Functionality using PGPy
 
 Author: Daniel Kahn Gillmor
-Date: 2019-10-24
-License: MIT (see below)
+Date: 2023-06-01
+License: 3-clause BSD, same as PGPy itself
 
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation files
-(the "Software"), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of the Software,
-and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 '''
 
 import io

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -126,8 +126,9 @@ class SOPGPy(sop.StatelessOpenPGP):
 
         subkey = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.ECDH,
                                  pgpy.constants.EllipticCurveOID.Curve25519)
-        subflags = pgpy.constants.KeyFlags.EncryptCommunications
-        subflags |= pgpy.constants.KeyFlags.EncryptStorage
+        subflags: Set[int] = set()
+        subflags.add(pgpy.constants.KeyFlags.EncryptCommunications)
+        subflags.add(pgpy.constants.KeyFlags.EncryptStorage)
         primary.add_subkey(subkey, usage=subflags)
         return self._maybe_armor(armor, primary)
 

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -380,11 +380,8 @@ class SOPGPy(sop.StatelessOpenPGP):
 
     def armor(self, data:bytes,
               label:sop.SOPArmorLabel=sop.SOPArmorLabel.auto,
-              allow_nested:bool=False,
               **kwargs:Namespace) -> bytes:
         self.raise_on_unknown_options(**kwargs)
-        if allow_nested: 
-            raise sop.SOPUnsupportedOption('sopgpy does not support --allow-nested yet')
         obj:Union[None,pgpy.PGPMessage,pgpy.PGPKey,pgpy.PGPSignature] = None
         try:
             if label is sop.SOPArmorLabel.message:

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -43,6 +43,8 @@ from datetime import datetime, timezone
 from typing import List, Union, Optional, Set, Tuple, MutableMapping, Dict, Callable
 from argparse import Namespace, _SubParsersAction, ArgumentParser
 
+from cryptography.hazmat.backends import openssl
+
 import sop
 import pgpy
 
@@ -68,8 +70,10 @@ class _multisig(pgpy.types.Armorable): #type: ignore
 class SOPGPy(sop.StatelessOpenPGP):
     def __init__(self) -> None:
         self.pgpy_version = packaging.version.Version(metadata.version('pgpy'))
+        self.cryptography_version = packaging.version.Version(metadata.version('cryptography'))
         super().__init__(name='SOPGPy', version=f'{self.pgpy_version}',
                          backend=f'PGPy {self.pgpy_version}',
+                         extended=f'python-cryptography {self.cryptography_version}\n{openssl.backend.openssl_version_text()}',
                          description=f'Stateless OpenPGP using PGPy {self.pgpy_version}')
 
     # implemented ciphers that we are willing to use to encrypt, in

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -64,7 +64,8 @@ class _multisig(pgpy.types.Armorable): #type: ignore
 class SOPGPy(sop.StatelessOpenPGP):
     def __init__(self) -> None:
         self.pgpy_version = packaging.version.Version(metadata.version('pgpy'))
-        super().__init__(name='SOPGPy', version=f'{__version__}/{self.pgpy_version}',
+        super().__init__(name='SOPGPy', version=f'{__version__}',
+                         backend=f'PGPy {self.pgpy_version}',
                          description=f'Stateless OpenPGP using PGPy {self.pgpy_version}')
 
     # implemented ciphers that we are willing to use to encrypt, in

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# PYTHON_ARGCOMPLETE_OK
 '''OpenPGP Interoperability Test Suite Generic Functionality using PGPy
 
 Author: Daniel Kahn Gillmor

--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -60,7 +60,8 @@ class SOPGPy(sop.StatelessOpenPGP):
 
     @property
     def generate_key_profiles(self) -> List[sop.SOPProfile]:
-        return [sop.SOPProfile('draft-koch-eddsa-for-openpgp-00', 'EdDSA/ECDH with Curve25519 ')]
+        return [sop.SOPProfile('draft-koch-eddsa-for-openpgp-00', 'EdDSA/ECDH with Curve25519 '),
+                sop.SOPProfile('rfc4880', '3072-bit RSA'),]
 
     @property
     def encrypt_profiles(self) -> List[sop.SOPProfile]:
@@ -148,8 +149,11 @@ class SOPGPy(sop.StatelessOpenPGP):
                      profile: Optional[sop.SOPProfile] = None,
                      **kwargs: Namespace) -> bytes:
         self.raise_on_unknown_options(**kwargs)
-        primary = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.EdDSA,
-                                  pgpy.constants.EllipticCurveOID.Ed25519)
+        if profile is not None and profile.name == 'rfc4880':
+            primary = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 3072)
+        else:
+            primary = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.EdDSA,
+                                      pgpy.constants.EllipticCurveOID.Ed25519)
         primaryflags: Set[int] = set()
         primaryflags.add(pgpy.constants.KeyFlags.Certify)
         primaryflags.add(pgpy.constants.KeyFlags.Sign)
@@ -173,8 +177,11 @@ class SOPGPy(sop.StatelessOpenPGP):
             if 'primary' in uidoptions: # only first User ID is Primary
                 del uidoptions['primary']
 
-        subkey = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.ECDH,
-                                 pgpy.constants.EllipticCurveOID.Curve25519)
+        if profile is not None and profile.name == 'rfc4880':
+            subkey = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 3072)
+        else:
+            subkey = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.ECDH,
+                                     pgpy.constants.EllipticCurveOID.Curve25519)
         subflags: Set[int] = set()
         subflags.add(pgpy.constants.KeyFlags.EncryptCommunications)
         subflags.add(pgpy.constants.KeyFlags.EncryptStorage)

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ packages =
 install_requires =
     cryptography>=3.3.2
     pyasn1
+    sop>=0.4.0
 python_requires = >=3.6
 
 # doc_requires =
@@ -54,3 +55,7 @@ python_requires = >=3.6
 source-dir = docs/source
 build-dir = docs/build
 all_files = 1
+
+[options.entry_points]
+console_scripts =
+    sopgpy = pgpy.sopgpy:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ packages =
 install_requires =
     cryptography>=3.3.2
     pyasn1
-    sop>=0.4.0
+    sop>=0.5.1
 python_requires = >=3.6
 
 # doc_requires =


### PR DESCRIPTION
This series takes the history of `sopgpy` (which has been in use by the [OpenPGP interoperability test suite](https://tests.sequoia-pgp.org/) for a while now) and merges it into the PGPy repository itself.

This way, people who install PGPy will also get a command-line tool to do simple keygen/encrypt/decrypt/sign/verify operations.  It also makes it easier for the interop test suite to pull in new features and bugfixes from PGPy, if they're available.