### PR TITLE
drop use of imghdr

### DIFF
--- a/pgpy/constants.py
+++ b/pgpy/constants.py
@@ -2,7 +2,6 @@
 """
 import bz2
 import hashlib
-import imghdr
 import os
 import zlib
 import warnings
@@ -429,8 +428,7 @@ class ImageEncoding(IntEnum):
 
     @classmethod
     def encodingof(cls, imagebytes):
-        type = imghdr.what(None, h=imagebytes)
-        if type == 'jpeg':
+        if imagebytes[6:10] in (b'JFIF', b'Exif') or imagebytes[:4] == b'\xff\xd8\xff\xdb':
             return ImageEncoding.JPEG
         return ImageEncoding.Unknown  # pragma: no cover
 


### PR DESCRIPTION
imghdr is deprecated and will be removed in python 3.13 (see https://peps.python.org/pep-0594/#imghdr)

The relevant code in imghdr is just:

```
def test_jpeg(h, f):
    """JPEG data with JFIF or Exif markers; and raw JPEG"""
    if h[6:10] in (b'JFIF', b'Exif'):
        return 'jpeg'
    elif h[:4] == b'\xff\xd8\xff\xdb':
        return 'jpeg'
```

So we transplant it directly