### PR TITLE
tests: Avoid passing naive datetime objects

### DIFF
--- a/tests/test_99_regressions.py
+++ b/tests/test_99_regressions.py
@@ -19,7 +19,7 @@ from pgpy.types import Armorable
 def test_reg_bug_56():
     # some imports only used by this regression test
     import hashlib
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     from pgpy.pgp import PGPSignature
 
@@ -135,7 +135,7 @@ def test_reg_bug_56():
 
     sig = PGPSignature.new(SignatureType.BinaryDocument, PubKeyAlgorithm.RSAEncryptOrSign, HashAlgorithm.SHA512,
                            sk.fingerprint.keyid)
-    sig._signature.subpackets['h_CreationTime'][-1].created = datetime(2014, 8, 6, 23, 28, 51)
+    sig._signature.subpackets['h_CreationTime'][-1].created = datetime(2014, 8, 6, 23, 28, 51, tzinfo=timezone.utc)
     sig._signature.subpackets.update_hlen()
     hdata = sig.hashdata(sigsubject)
     sig._signature.hash2 = hashlib.new('sha512', hdata).digest()[:2]


### PR DESCRIPTION
this removes another warning from the test suite, which makes it a bit quieter