### PR TITLE
rename setter for EmbeddedSignature._sig (otherwise definition was aliased)

### DIFF
--- a/pgpy/packet/subpackets/signature.py
+++ b/pgpy/packet/subpackets/signature.py
@@ -848,7 +848,7 @@ class EmbeddedSignature(Signature):
         return self._sigpkt
 
     @_sig.setter
-    def _sig(self, val):
+    def _sig_set(self, val):
         esh = EmbeddedSignatureHeader()
         esh.version = val.header.version
         val.header = esh


### PR DESCRIPTION
i caught this by running mypy on the codebase.