### PR TITLE
Drop erroneous SubkeyBindingSignature

### DIFF
--- a/pgpy/packet/subpackets/signature.py
+++ b/pgpy/packet/subpackets/signature.py
@@ -52,7 +52,6 @@ __all__ = ['URI',
            'Policy',
            'KeyFlags',
            'SignersUserID',
-           'SubkeyBindingSignature',
            'ReasonForRevocation',
            'Features',
            'EmbeddedSignature',
@@ -704,11 +703,7 @@ class PreferredKeyServer(URI):
     __typeid__ = 0x18
 
 
-class SubkeyBindingSignature(Signature):
-    __typeid__ = 0x18
-
-
-class PrimaryUserID(SubkeyBindingSignature):
+class PrimaryUserID(Signature):
     __typeid__ = 0x19
 
     @sdproperty


### PR DESCRIPTION
This is not a signature subpacket.  Rather, it is a signature type.