### PR TITLE
OPSv3: get the "nested" flag right

### DIFF
--- a/pgpy/packet/packets.py
+++ b/pgpy/packet/packets.py
@@ -718,7 +718,7 @@ class OnePassSignatureV3(OnePassSignature):
         _bytes += bytearray([self.halg])
         _bytes += bytearray([self.pubalg])
         _bytes += binascii.unhexlify(self.signer.encode("latin-1"))
-        _bytes += bytearray([int(self.nested)])
+        _bytes += bytearray([int(not self.nested)])
         return _bytes
 
     def parse(self, packet):
@@ -735,7 +735,7 @@ class OnePassSignatureV3(OnePassSignature):
         self.signer = packet[:8]
         del packet[:8]
 
-        self.nested = (packet[0] == 1)
+        self.nested = (packet[0] == 0)
         del packet[0]
 
 

--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -1018,7 +1018,7 @@ class PGPMessage(Armorable, PGPObject):
             ##TODO: is it worth coming up with a way of disabling one-pass signing?
             for sig in reversed(self._signatures):
                 ops = sig.make_onepass()
-                if sig is not self._signatures[-1]:
+                if sig is not self._signatures[0]:
                     ops.nested = True
                 yield ops
 


### PR DESCRIPTION
"nested" semantically probably is meant to mean "another OPS packet follows". But the byte on the wire is defined as 0 means another OPS packet follows.

Furthermore, the flags are set in the wrong way: before this commit, the code produced a series of OPS packets where the first packet had a different value for the flag than all subsequent ones.  What we want is where all the flags *except* the last OPS packet (corresponding to the *first* Sig packet) are 0.

See https://gitlab.com/sequoia-pgp/openpgp-interoperability-test-suite/-/issues/84