### PR TITLE
PGPKey.from_file,from_blob: Drop failed filtering of keyid mapping

### DIFF
--- a/pgpy/pgp.py
+++ b/pgpy/pgp.py
@@ -2670,9 +2670,6 @@ class PGPKey(Armorable, ParentRef, PGPObject):
             for pkt in group:  # pragma: no cover
                 orphaned.append(pkt)
 
-        # remove the reference to self from keys
-        [ keys.pop((getattr(self, 'fingerprint.keyid', '~'), None), t) for t in (True, False) ]
-        # return {'keys': keys, 'orphaned': orphaned}
         return keys
 
 


### PR DESCRIPTION
This appears to have been introduced in
38a4f9f8b17fd40a2be942f58db2ecd8e67a32ee nearly 9 years ago, but it doesn't look like it ever worked.

It's not clear to me why this index of keys by key ID is returned at all in these functions, but since September 2014 (v0.3.0) the index has always returned the key ID of the primary key anyway.

There are a few things broken in this particular line:

 - the use of `~` if `fingerprint.keyid` doesn't work for some reason: that won't match anything.
 - and, `None` gets passed as the second object in the tuple, but the second object should be either `True` or `False`, suggesting that `t` is being misused.

Rather than try to salvage something that i don't understand in the first place, i figure it's better to drop it and acknowledge the status quo.