### PR TITLE
CI: Restore actions to a working state

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        os: [ubuntu-22.04, macos-12]
+        python-version: [3.8, 3.9, '3.10', 3.11]
 
     steps:
       - uses: actions/checkout@v2
@@ -30,13 +30,13 @@ jobs:
 
   # do some tests with LC_ALL=C to check for locale variance
   c-locale-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.11
       - name: Install requirements
         run: |
           sed -i -e 's/^/#/' tests/gnupghome/gpg-agent.conf
@@ -55,20 +55,18 @@ jobs:
 
   # test setup.py using each tested version
   test-setup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
-          - python-version: 3.6
-            env: py36-setup
-          - python-version: 3.7
-            env: py37-setup
           - python-version: 3.8
             env: py38-setup
           - python-version: 3.9
             env: py39-setup
           - python-version: '3.10'
             env: py310-setup
+          - python-version: 3.11
+            env: py311-setup
 
     steps:
       - uses: actions/checkout@v2
@@ -83,13 +81,13 @@ jobs:
 
   # add a pep8 test
   pep8:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     continue-on-error: true # pep8 failures shouldn't be considered fatal
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.11
       - name: Install tox
         run: pip install tox
       - name: Run tox
@@ -98,12 +96,12 @@ jobs:
   # report coverage to coveralls, but only for pytest runs
   finish-coveralls:
     needs: [ unit-tests, c-locale-test ]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.11
       - name: Finish Coveralls
         run: |
           pip install coveralls

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,31 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,9 @@ You can also join ``#pgpy`` on Freenode to ask questions or get involved
 Requirements
 ------------
 
-- Python >= 3.6
+- Python >= 3.8
 
-  Tested with: 3.10, 3.9, 3.8, 3.7, 3.6
+  Tested with: 3.11, 3.10, 3.9, 3.8
 
 - `Cryptography <https://pypi.python.org/pypi/cryptography>`_
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310}{,-setup}, pypy3, pep8
+envlist = py{38,39,310,311}{,-setup}, pypy3, pep8
 skipsdist = True
 
 [pytest]
@@ -38,7 +38,7 @@ install_command = pip install {opts} --no-cache-dir {packages}
 commands =
     py.test --cov pgpy --cov-report term-missing tests/
 
-[testenv:py{36,37,38,39,310}-setup]
+[testenv:py{38,39,310,311}-setup]
 recreate = True
 allowlist_externals =
     /usr/bin/rm
@@ -49,7 +49,7 @@ commands =
     rm -rf PGPy.egg-info
 
 [testenv:pep8]
-basepython = python3.6
+basepython = python3.11
 deps =
     flake8
     pep8-naming


### PR DESCRIPTION
- Github images for Ubuntu 18.04 and MacOS 10.15 were dropped a while back
- Python 3.6 and 3.7 aren't supported anymore

Restore github actions to a working state to help you triage faster which Merge Requests deserve attention